### PR TITLE
Command argument abstraction per project type

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs/CmdArgsPackage.cs
@@ -184,24 +184,9 @@ namespace SmartCmdArgs
 
             if (found)
             {
-                EnvDTE.Properties properties = project.ConfigurationManager?.ActiveConfiguration?.Properties;
-
-                if (properties != null)
-                {
-                    var activeEntries = ToolWindowViewModel.ActiveItemsForCurrentProject().Select(e => e.Command);
-                    string prjCmdArgs = string.Join(" ", activeEntries);
-
-                    foreach (EnvDTE.Property prop in properties)
-                    {
-                        // CommandArguments = C/C++ project
-                        // StartArguments   = C#/VB project
-                        if (prop.Name == "CommandArguments" || prop.Name == "StartArguments")
-                        {
-                            prop.Value = prjCmdArgs;
-                            break;
-                        }
-                    }
-                }
+                var activeEntries = ToolWindowViewModel.ActiveItemsForCurrentProject().Select(e => e.Command);
+                string prjCmdArgs = string.Join(" ", activeEntries);
+                Helper.ProjectArguments.SetArguments(project, prjCmdArgs);
             }
         }
 
@@ -303,27 +288,7 @@ namespace SmartCmdArgs
             foreach (EnvDTE.Project project in allProjects)
             {
                 List<string> prjCmdArgs = new List<string>();
-                // Read properties for all configurations (e.g. Debug/Release)
-                foreach (EnvDTE.Configuration config in project.ConfigurationManager)
-                {
-                    if (config.Properties == null)
-                        continue;
-
-                    foreach (EnvDTE.Property prop in config.Properties)
-                    {
-                        // CommandArguments = C/C++ project
-                        // StartArguments   = C#/VB project
-                        if (prop.Name != "CommandArguments" && prop.Name != "StartArguments")
-                            continue;
-
-                        string cmdarg = prop.Value as string;
-                        if (!string.IsNullOrEmpty(cmdarg))
-                        {
-                            prjCmdArgs.Add(cmdarg);
-                        }
-                        break;
-                    }
-                }
+                Helper.ProjectArguments.AddAllArguments(project, prjCmdArgs);
                 dict.Add(project.UniqueName, prjCmdArgs.Distinct().ToList());
             }
 

--- a/SmartCmdArgs/SmartCmdArgs/Helper/ProjectArguments.cs
+++ b/SmartCmdArgs/SmartCmdArgs/Helper/ProjectArguments.cs
@@ -1,0 +1,109 @@
+﻿using SmartCmdArgs.ViewModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+
+namespace SmartCmdArgs.Helper
+{
+    public static class ProjectArguments
+    {
+        private class ProjectArgumentsHandlers
+        {
+            public delegate void SetArgumentsDelegate(EnvDTE.Project project, string arguments);
+            public delegate void GetAllArgumentsDelegate(EnvDTE.Project project, List<string> allArgs);
+            public SetArgumentsDelegate SetArguments;
+            public GetAllArgumentsDelegate GetAllArguments;
+        }
+
+        private static void SetSingleConfigArgument(EnvDTE.Project project, string arguments, string propertyName)
+        {
+            try {project.Properties.Item(propertyName).Value = arguments; } catch { }
+        }
+
+        private static void GetSingleConfigAllArguments(EnvDTE.Project project, List<string> allArgs, string propertyName)
+        {
+            try
+            {
+                string cmdarg = project.Properties.Item(propertyName).Value as string;
+                if (!string.IsNullOrEmpty(cmdarg))
+                {
+                    allArgs.Add(cmdarg);
+                }
+            }
+            catch { }
+        }
+
+        private static void SetMultiConfigArguments(EnvDTE.Project project, string arguments, string propertyName)
+        {
+            // Set the arguments only on the active configuration
+            EnvDTE.Properties properties = project.ConfigurationManager?.ActiveConfiguration?.Properties;
+            try { properties.Item(propertyName).Value = arguments; } catch { }
+        }
+
+        private static void GetMultiConfigAllArguments(EnvDTE.Project project, List<string> allArgs, string propertyName)
+        {
+            // Read properties for all configurations (e.g. Debug/Release)
+            foreach (EnvDTE.Configuration config in project.ConfigurationManager)
+            {
+                try {
+                    string cmdarg = config.Properties.Item(propertyName).Value as string;
+                    if (!string.IsNullOrEmpty(cmdarg))
+                    {
+                        allArgs.Add(cmdarg);
+                    }
+                }
+                catch { }
+            }
+        }
+
+        private static Dictionary<string, ProjectArgumentsHandlers> supportedProjects = new Dictionary<string, ProjectArgumentsHandlers>()
+        {
+            // C#
+            {"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", new ProjectArgumentsHandlers() {
+                SetArguments = (project, arguments) => SetMultiConfigArguments(project, arguments, "CommandArguments"),
+                GetAllArguments = (project, allArgs) => GetMultiConfigAllArguments(project, allArgs, "CommandArguments")
+            } },
+            // VB.NET
+            {"{F184B08F-C81C-45F6-A57F-5ABD9991F28F}", new ProjectArgumentsHandlers() {
+                SetArguments = (project, arguments) => SetMultiConfigArguments(project, arguments, "CommandArguments"),
+                GetAllArguments = (project, allArgs) => GetMultiConfigAllArguments(project, allArgs, "CommandArguments")
+            } },
+            // C/C++
+            {"{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}", new ProjectArgumentsHandlers() {
+                SetArguments = (project, arguments) => SetMultiConfigArguments(project, arguments, "StartArguments"),
+                GetAllArguments = (project, allArgs) => GetMultiConfigAllArguments(project, allArgs, "StartArguments")
+            } },
+            // Python
+            {"{888888a0-9f3d-457c-b088-3a5042f75d52}", new ProjectArgumentsHandlers() {
+                SetArguments = (project, arguments) => SetSingleConfigArgument(project, arguments, "CommandLineArguments"),
+                GetAllArguments = (project, allArgs) => GetSingleConfigAllArguments(project, allArgs, "CommandLineArguments")
+            } },
+        };
+
+        public static bool IsSupportedProject(EnvDTE.Project project)
+        {
+            return supportedProjects.ContainsKey(project.Kind);
+        }
+
+        public static void AddAllArguments(EnvDTE.Project project, List<string> allArgs)
+        {
+            ProjectArgumentsHandlers handler;
+            if (supportedProjects.TryGetValue(project.Kind, out handler))
+            {
+                handler.GetAllArguments(project, allArgs);
+            }
+        }
+
+        public static void SetArguments(EnvDTE.Project project, string arguments)
+        {
+            ProjectArgumentsHandlers handler;
+            if (supportedProjects.TryGetValue(project.Kind, out handler))
+            {
+                handler.SetArguments(project, arguments);
+            }
+        }
+    }
+}

--- a/SmartCmdArgs/SmartCmdArgs/SmartCmdArgs.csproj
+++ b/SmartCmdArgs/SmartCmdArgs/SmartCmdArgs.csproj
@@ -60,6 +60,7 @@
     </Compile>
     <Compile Include="Helper\DelayExecution.cs" />
     <Compile Include="Helper\ObservableCollectionEx.cs" />
+    <Compile Include="Helper\ProjectArguments.cs" />
     <Compile Include="Logic\ToolWindowProjectDataSerializer.cs" />
     <Compile Include="Logic\ToolWindowSolutionDataSerializer.cs" />
     <Compile Include="Logic\ToolWindowStateData.cs" />

--- a/SmartCmdArgs/SmartCmdArgs/VisualStudioHelper.cs
+++ b/SmartCmdArgs/SmartCmdArgs/VisualStudioHelper.cs
@@ -105,7 +105,7 @@ namespace SmartCmdArgs
 
             // We determine if this is an actual project by looking if it has a ConfigurationManager
             // This could be wrong for some types of project, but it works for our needs
-            if (project.ConfigurationManager != null)
+            if (SmartCmdArgs.Helper.ProjectArguments.IsSupportedProject(project))
             {
                 allProjects.Add(project);
             }


### PR DESCRIPTION
Abstract how to get/set project arguments by project type (#9). 
Add support for Python projects. (depends on https://github.com/Microsoft/PTVS/pull/1335 , will silently fail if missing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mbulli/smartcommandlineargs/11)
<!-- Reviewable:end -->
