### PR TITLE
Use FullName instead of FileName when searching for .args.json path

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs/CmdArgsPackage.cs
@@ -441,7 +441,7 @@ namespace SmartCmdArgs
 
         private string FullFilenameForProjectJsonFile(EnvDTE.Project project)
         {
-            return FullFilenameForProjectJsonFile(project.FileName);
+            return FullFilenameForProjectJsonFile(project.FullName);
         }
 
         private string FullFilenameForProjectJsonFile(string projectFile)


### PR DESCRIPTION
Some project type don't have the full path in `project.FileName` (python projects for instance).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mbulli/smartcommandlineargs/13)
<!-- Reviewable:end -->
