### PR TITLE
Set BitmapResourceID for ToolWindow

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs/ToolWindow.cs
+++ b/SmartCmdArgs/SmartCmdArgs/ToolWindow.cs
@@ -62,6 +62,12 @@ namespace SmartCmdArgs
             this.view = new View.ToolWindowControl(viewModel);
             this.Content = view;
 
+            // Id from VSPackage.resx.
+            BitmapResourceID = 300;
+
+            // The index is actually zero-based, in contrast to the bitmaps in the vsct-file.
+            BitmapIndex = 0;
+
             this.ToolBar = new CommandID(Commands.CmdArgsToolBarCmdSet, Commands.TWToolbar);
 
             matchCaseSearchOption = new WindowSearchBooleanOption("Match Case", "Enable to make search case sensitive.", false);

--- a/SmartCmdArgs/SmartCmdArgs/VSPackage.resx
+++ b/SmartCmdArgs/SmartCmdArgs/VSPackage.resx
@@ -134,4 +134,8 @@
   <data name="200" xml:space="preserve">
     <value>Smart Cmd Args Window</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="300" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\VSMeuIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>


### PR DESCRIPTION
This sets the icon on the ToolWindow which adds an icon when
1) The tool window is too narrow to display its text (currently the icon is just empty)
2) Enables the Iconizer VS extension to display the toolwindow's icon instead of the text

![sca](https://user-images.githubusercontent.com/5563601/50516684-93b0c900-0aac-11e9-9477-050f2d1bbe9b.png)
