### PR TITLE
Add support for google android native project arguments

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs/Helper/ProjectArguments.cs
+++ b/SmartCmdArgs/SmartCmdArgs/Helper/ProjectArguments.cs
@@ -104,6 +104,12 @@ namespace SmartCmdArgs.Helper
                     windowsRemoteDebugger.SetPropertyValue("RemoteDebuggerCommandArguments", arguments);
                 }
                 else { Logger.Warn("SetVCProjEngineArguments: ProjectConfig Rule 'RemoteDebuggerCommandArguments' returned null"); }
+
+                dynamic googleAndroidDebugger = vcCfg.Rules.Item( "GoogleAndroidDebugger" ); // is IVCRulePropertyStorage
+                if( googleAndroidDebugger != null )
+                {
+                    googleAndroidDebugger.SetPropertyValue( "LaunchFlags", arguments );
+                }
             }
             else { Logger.Warn("SetVCProjEngineArguments: VCProject?.ActiveConfiguration? returned null"); }
         }


### PR DESCRIPTION
This allow the extension to send the launch arguments to the google android native application flow, it wasn't working since it's using another rule item in the vcCfg. I've been testing this change for a few months using various kinds of projects (android, c++ and c# ones mainly) and haven't encountered any major issues.