### PR TITLE
Fix SuoDataSerializer crash when parsing corrupted suo file

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs.Shared/Logic/SuoDataSerializer.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Logic/SuoDataSerializer.cs
@@ -40,16 +40,16 @@ namespace SmartCmdArgs.Logic
                 return new SuoDataJson();
             }
 
-            // At the moment there are two json formats.
-            // The 'old' format and the new one.
-            // The FileVersion property was introduced with the new format
-            // Hence, a missing FileVersion indicates the old format.
-            var obj = JObject.Parse(jsonStr);
-            int fileVersion = ((int?)obj["FileVersion"]).GetValueOrDefault();
-            Logger.Info($"Suo json file version is '{fileVersion}'");
-
             try
             {
+                // At the moment there are two json formats.
+                // The 'old' format and the new one.
+                // The FileVersion property was introduced with the new format
+                // Hence, a missing FileVersion indicates the old format.
+                var obj = JObject.Parse(jsonStr);
+                int fileVersion = ((int?)obj["FileVersion"]).GetValueOrDefault();
+                Logger.Info($"Suo json file version is '{fileVersion}'");
+
                 if (fileVersion < 2)
                 {
                     return ParseOldJsonFormat(obj, vsHelper);


### PR DESCRIPTION
Visual Studio 2022 has a fantastic bug where when running out of memory it can corrupt the .suo file. The try/catch statement for SuoDataSerializer::Deserialize isn't catching any issues with the call to JObject::Parse causing the extension to enter a crash loop.

This fix shoves the offending code into the nearby try/catch statement.