### PR TITLE
Add Platform filter to argument groups

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
@@ -261,6 +261,7 @@ namespace SmartCmdArgs
                 return null;
 
             string projConfig = project.GetProject()?.ConfigurationManager?.ActiveConfiguration?.ConfigurationName;
+            string projPlatform = project.GetProject()?.ConfigurationManager?.ActiveConfiguration?.PlatformName;
 
             string activeLaunchProfile = null;
             if (project.IsCpsProject())
@@ -282,6 +283,9 @@ namespace SmartCmdArgs
                 if (projConfig != null)
                     items = items.Where(x => { var conf = x.UsedProjectConfig; return conf == null || conf == projConfig; });
 
+                if (projPlatform != null)
+                    items = items.Where(x => { var plat = x.UsedProjectPlatform; return plat == null || plat == projPlatform; });
+
                 if (activeLaunchProfile != null)
                     items = items.Where(x => { var prof = x.UsedLaunchProfile; return prof == null || prof == activeLaunchProfile; });
 
@@ -302,6 +306,14 @@ namespace SmartCmdArgs
             
             var configs = (project.GetProject()?.ConfigurationManager?.ConfigurationRowNames as Array)?.Cast<string>().ToList();
             return configs ?? new List<string>();
+        }
+
+        public List<string> GetProjectPlatforms(Guid projGuid)
+        {
+            IVsHierarchy project = vsHelper.HierarchyForProjectGuid(projGuid);
+
+            var platforms = (project.GetProject()?.ConfigurationManager?.PlatformNames as Array)?.Cast<string>().ToList();
+            return platforms ?? new List<string>();
         }
 
         public List<string> GetLaunchProfiles(Guid projGuid)

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Helper/ProjectArguments.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Helper/ProjectArguments.cs
@@ -72,7 +72,7 @@ namespace SmartCmdArgs.Helper
                     string cmdarg = config.Properties.Item(propertyName).Value as string;
                     if (!string.IsNullOrEmpty(cmdarg))
                     {
-                        var configGrp = new CmdArgumentJson { Command = config.ConfigurationName, ProjectConfig = config.ConfigurationName, Items = new List<CmdArgumentJson>() };
+                        var configGrp = new CmdArgumentJson { Command = config.ConfigurationName, ProjectConfig = config.ConfigurationName, ProjectPlatform = config.PlatformName, Items = new List<CmdArgumentJson>() };
                         configGrp.Items.Add(new CmdArgumentJson { Command = cmdarg, Enabled = true });
                         allArgs.Add(configGrp);
                     }
@@ -162,7 +162,7 @@ namespace SmartCmdArgs.Helper
 
                 if (items.Count > 0)
                 {
-                    var configGrp = new CmdArgumentJson { Command = cfg.ConfigurationName, ProjectConfig = cfg.ConfigurationName, Items = new List<CmdArgumentJson>() };
+                    var configGrp = new CmdArgumentJson { Command = cfg.ConfigurationName, ProjectConfig = cfg.ConfigurationName, ProjectPlatform = cfg.PlatformName, Items = new List<CmdArgumentJson>() };
 
                     configGrp.Items.AddRange(items.Distinct().Select(arg => new CmdArgumentJson { Command = arg, Enabled = true }));
 
@@ -237,7 +237,7 @@ namespace SmartCmdArgs.Helper
 
                 if (!string.IsNullOrEmpty(dbg?.CommandArguments))
                 {
-                    var configGrp = new CmdArgumentJson { Command = vcCfg.ConfigurationName, ProjectConfig = vcCfg.ConfigurationName, Items = new List<CmdArgumentJson>() };
+                    var configGrp = new CmdArgumentJson { Command = vcCfg.ConfigurationName, ProjectConfig = vcCfg.ConfigurationName, ProjectPlatform = vcCfg.PlatformName, Items = new List<CmdArgumentJson>() };
                     configGrp.Items.Add(new CmdArgumentJson { Command = dbg.CommandArguments });
                     allArgs.Add(configGrp);
                 }

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Logic/DataSerializer.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Logic/DataSerializer.cs
@@ -19,6 +19,7 @@ namespace SmartCmdArgs.Logic
                     Id = item.Id,
                     Command = item.Value,
                     ProjectConfig = item.ProjectConfig,
+                    ProjectPlatform = item.ProjectPlatform,
                     LaunchProfile = item.LaunchProfile,
 
                     // not in JSON

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Logic/JsonDataObjects.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Logic/JsonDataObjects.cs
@@ -66,6 +66,8 @@ namespace SmartCmdArgs.Logic
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string ProjectConfig = null;
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string ProjectPlatform = null;
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string LaunchProfile = null;
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public bool ExclusiveMode = false;

--- a/SmartCmdArgs/SmartCmdArgs.Shared/View/ArgumentItemView.xaml
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/View/ArgumentItemView.xaml
@@ -26,12 +26,14 @@
                 <TextBlock.Text>
                     <MultiBinding Converter="{c:StringConcatConverter Seperator=' | '}">
                         <Binding Path="ProjectConfig" Mode="OneWay"/>
+                        <Binding Path="ProjectPlatform" Mode="OneWay"/>
                         <Binding Path="LaunchProfile" Mode="OneWay"/>
                     </MultiBinding>
                 </TextBlock.Text>
                 <TextBlock.Visibility>
                     <MultiBinding Converter="{c:NullToVisibilityMultiConverter VisibleCondition=AnyNotNull, HideVisibility=Collapsed}">
                         <Binding Path="ProjectConfig" Mode="OneWay"/>
+                        <Binding Path="ProjectPlatform" Mode="OneWay"/>
                         <Binding Path="LaunchProfile" Mode="OneWay"/>
                     </MultiBinding>
                 </TextBlock.Visibility>

--- a/SmartCmdArgs/SmartCmdArgs.Shared/View/ToolWindowControl.xaml
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/View/ToolWindowControl.xaml
@@ -37,6 +37,7 @@
                           NewGroupFromArgumentsCommand="{Binding NewGroupFromArgumentsCommand}"
                           SetAsStartupProjectCommand="{Binding SetAsStartupProjectCommand}"
                           SetProjectConfigCommand="{Binding SetProjectConfigCommand}"
+                          SetProjectPlatformCommand="{Binding SetProjectPlatformCommand}"
                           SetLaunchProfileCommand="{Binding SetLaunchProfileCommand}"
                           ToggleExclusiveModeCommand="{Binding ToggleExclusiveModeCommand}"
                           ToggleSpaceDelimiterCommand="{Binding ToggleSpaceDelimiterCommand}"

--- a/SmartCmdArgs/SmartCmdArgs.Shared/View/TreeViewEx.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/View/TreeViewEx.cs
@@ -96,6 +96,10 @@ namespace SmartCmdArgs.View
             nameof(SetProjectConfigCommand), typeof(ICommand), typeof(TreeViewEx), new PropertyMetadata(default(ICommand)));
         public ICommand SetProjectConfigCommand { get { return (ICommand)GetValue(SetProjectConfigCommandProperty); } set { SetValue(SetProjectConfigCommandProperty, value); } }
 
+        public static readonly DependencyProperty SetProjectPlatformCommandProperty = DependencyProperty.Register(
+            nameof(SetProjectPlatformCommand), typeof(ICommand), typeof(TreeViewEx), new PropertyMetadata(default(ICommand)));
+        public ICommand SetProjectPlatformCommand { get { return (ICommand)GetValue(SetProjectPlatformCommandProperty); } set { SetValue(SetProjectPlatformCommandProperty, value); } }
+
         public static readonly DependencyProperty SetLaunchProfileCommandProperty = DependencyProperty.Register(
             nameof(SetLaunchProfileCommand), typeof(ICommand), typeof(TreeViewEx), new PropertyMetadata(default(ICommand)));
         public ICommand SetLaunchProfileCommand { get { return (ICommand)GetValue(SetLaunchProfileCommandProperty); } set { SetValue(SetLaunchProfileCommandProperty, value); } }
@@ -155,6 +159,7 @@ namespace SmartCmdArgs.View
         private MenuItem _newGroupFromArgumentsMenuItem;
         private MenuItem _setAsStartupProjectMenuItem;
         private MenuItem _projConfigMenuItem;
+        private MenuItem _projPlatformMenuItem;
         private MenuItem _launchProfileMenuItem;
         private MenuItem _defaultCheckedMenuItem;
         private MenuItem _resetToDefaultMenuItem;
@@ -176,6 +181,7 @@ namespace SmartCmdArgs.View
             ContextMenu.Items.Add(_splitArgumentMenuItem = new MenuItem { Header = "Split Argument" });
             ContextMenu.Items.Add(_setAsStartupProjectMenuItem = new MenuItem { Header = "Set as single Startup Project" });
             ContextMenu.Items.Add(_projConfigMenuItem = new MenuItem { Header = "Project Configuration" });
+            ContextMenu.Items.Add(_projPlatformMenuItem = new MenuItem { Header = "Project Platform" });
             ContextMenu.Items.Add(_launchProfileMenuItem = new MenuItem { Header = "Launch Profile" });
             ContextMenu.Items.Add(_defaultCheckedMenuItem = new MenuItem { Header = "Default Checked", IsCheckable = true });
             ContextMenu.Items.Add(_resetToDefaultMenuItem = new MenuItem { Header = "Reset to default checked" });
@@ -184,6 +190,7 @@ namespace SmartCmdArgs.View
             CollapseWhenDisbaled(_splitArgumentMenuItem);
             CollapseWhenDisbaled(_setAsStartupProjectMenuItem);
             CollapseWhenDisbaled(_projConfigMenuItem);
+            CollapseWhenDisbaled(_projPlatformMenuItem);
             CollapseWhenDisbaled(_launchProfileMenuItem);
             CollapseWhenDisbaled(_defaultCheckedMenuItem);
             CollapseWhenDisbaled(_resetToDefaultMenuItem);
@@ -239,9 +246,11 @@ namespace SmartCmdArgs.View
         private void OnContextMenuOpening(object sender, ContextMenuEventArgs e)
         {
             _projConfigMenuItem.Items.Clear();
+            _projPlatformMenuItem.Items.Clear();
             _launchProfileMenuItem.Items.Clear();
 
             _projConfigMenuItem.IsEnabled = false;
+            _projPlatformMenuItem.IsEnabled = false;
             _launchProfileMenuItem.IsEnabled = false;
 
             _defaultCheckedMenuItem.IsChecked = SelectedTreeViewItems.Select(x => x.Item).OfType<CmdArgument>().Any(x => x.DefaultChecked);
@@ -303,6 +312,36 @@ namespace SmartCmdArgs.View
                     }
                 }
 
+                if (SetProjectPlatformCommand.CanExecute(null))
+                {
+                    var platforms = CmdArgsPackage.Instance.GetProjectPlatforms(proj.Id);
+
+                    if (platforms.Count > 0 || group.ProjectPlatform != null)
+                    {
+                        _projPlatformMenuItem.IsEnabled = true;
+
+                        _projPlatformMenuItem.Items.Add(new MenuItem
+                        {
+                            Header = "All",
+                            Command = SetProjectPlatformCommand,
+                            CommandParameter = null,
+                            IsChecked = group.ProjectPlatform == null,
+                            IsCheckable = true
+                        });
+
+                        foreach (var platform in platforms)
+                        {
+                            _projPlatformMenuItem.Items.Add(new MenuItem
+                            {
+                                Header = platform,
+                                Command = SetProjectPlatformCommand,
+                                CommandParameter = platform,
+                                IsChecked = group.ProjectPlatform == platform,
+                                IsCheckable = true
+                            });
+                        }
+                    }
+                }
 
                 if (SetLaunchProfileCommand.CanExecute(null))
                 {

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/CmdArgItem.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/CmdArgItem.cs
@@ -52,6 +52,10 @@ namespace SmartCmdArgs.ViewModel
         public string ProjectConfig { get => _projectConfig; protected set => OnProjectConfigChanged(this._projectConfig, value); }
         public string UsedProjectConfig => _projectConfig ?? Parent?.UsedProjectConfig;
 
+        private string _projectPlatform = null;
+        public string ProjectPlatform { get => _projectPlatform; protected set => OnProjectPlatformChanged(this._projectPlatform, value); }
+        public string UsedProjectPlatform => _projectPlatform ?? Parent?.UsedProjectPlatform;
+
         private string _launchProfile = null;
         public string LaunchProfile { get => _launchProfile; protected set => OnLaunchProfileChanged(this._launchProfile, value); }
         public string UsedLaunchProfile => _launchProfile ?? Parent?.UsedLaunchProfile;
@@ -151,6 +155,16 @@ namespace SmartCmdArgs.ViewModel
             if (oldValue != newValue)
             {
                 BubbleEvent(new ProjectConfigChangedEvent(this, oldValue, newValue));
+            }
+        }
+
+        private void OnProjectPlatformChanged(string oldValue, string newValue)
+        {
+            SetAndNotify(newValue, ref _projectPlatform, nameof(ProjectPlatform));
+
+            if (oldValue != newValue)
+            {
+                BubbleEvent(new ProjectPlatformChangedEvent(this, oldValue, newValue));
             }
         }
 
@@ -696,26 +710,33 @@ namespace SmartCmdArgs.ViewModel
             set => base.ProjectConfig = value;
         }
 
+        public new string ProjectPlatform
+        {
+            get => base.ProjectPlatform;
+            set => base.ProjectPlatform = value;
+        }
+
         public new string LaunchProfile
         {
             get => base.LaunchProfile;
             set => base.LaunchProfile = value;
         }
 
-        public CmdGroup(Guid id, string name, IEnumerable<CmdBase> items, bool isExpanded, bool exclusiveMode, string projConf, string launchProfile, string delimiter) 
+        public CmdGroup(Guid id, string name, IEnumerable<CmdBase> items, bool isExpanded, bool exclusiveMode, string projConf, string projPlatform, string launchProfile, string delimiter)
             : base(id, name, items, isExpanded, exclusiveMode, delimiter)
         {
             base.ProjectConfig = projConf;
+            base.ProjectPlatform = projPlatform;
             base.LaunchProfile = launchProfile;
         }
 
-        public CmdGroup(string name, IEnumerable<CmdBase> items = null, bool isExpanded = true, bool exclusiveMode = false, string projConf = null, string launchProfile = null, string delimiter = " ") 
-            : this(Guid.NewGuid(), name, items, isExpanded, exclusiveMode, projConf, launchProfile, delimiter)
+        public CmdGroup(string name, IEnumerable<CmdBase> items = null, bool isExpanded = true, bool exclusiveMode = false, string projConf = null, string projPlatform = null, string launchProfile = null, string delimiter = " ")
+            : this(Guid.NewGuid(), name, items, isExpanded, exclusiveMode, projConf, projPlatform, launchProfile, delimiter)
         { }
 
         public override CmdBase Copy()
         {
-            return new CmdGroup(Value, Items.Select(cmd => cmd.Copy()), isExpanded, ExclusiveMode, ProjectConfig, LaunchProfile, Delimiter);
+            return new CmdGroup(Value, Items.Select(cmd => cmd.Copy()), isExpanded, ExclusiveMode, ProjectConfig, ProjectPlatform, LaunchProfile, Delimiter);
         }
     }
 

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/DataObjectGenerator.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/DataObjectGenerator.cs
@@ -136,6 +136,9 @@ namespace SmartCmdArgs.ViewModel
             public string ProjectConfig { get; set; } = null;
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public string ProjectPlatform { get; set; } = null;
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public string LaunchProfile { get; set; } = null;
 
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
@@ -161,7 +164,7 @@ namespace SmartCmdArgs.ViewModel
                     }
                     else if (cmd is CmdGroup grp)
                     {
-                        yield return new DataObjectJsonItem {Value = grp.Value, ProjectConfig = grp.ProjectConfig, LaunchProfile = grp.LaunchProfile, ExclusiveMode = grp.ExclusiveMode, Delimiter = grp.Delimiter, Items = Convert(grp.Items)};
+                        yield return new DataObjectJsonItem {Value = grp.Value, ProjectConfig = grp.ProjectConfig, ProjectPlatform = grp.ProjectPlatform, LaunchProfile = grp.LaunchProfile, ExclusiveMode = grp.ExclusiveMode, Delimiter = grp.Delimiter, Items = Convert(grp.Items)};
                     }
                 }
             }
@@ -176,7 +179,7 @@ namespace SmartCmdArgs.ViewModel
                     }
                     else
                     {
-                        yield return new CmdGroup(item.Value, Convert(item.Items), exclusiveMode: item.ExclusiveMode, projConf: item.ProjectConfig, launchProfile: item.LaunchProfile, delimiter: item.Delimiter);
+                        yield return new CmdGroup(item.Value, Convert(item.Items), exclusiveMode: item.ExclusiveMode, projConf: item.ProjectConfig, projPlatform: item.ProjectPlatform, launchProfile: item.LaunchProfile, delimiter: item.Delimiter);
                     }
                 }
             }

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/ToolWindowViewModel.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/ToolWindowViewModel.cs
@@ -71,6 +71,8 @@ namespace SmartCmdArgs.ViewModel
 
         public RelayCommand<string> SetProjectConfigCommand { get; }
 
+        public RelayCommand<string> SetProjectPlatformCommand { get; }
+
         public RelayCommand<string> SetLaunchProfileCommand { get; }
 
         public RelayCommand ToggleExclusiveModeCommand { get; }
@@ -231,6 +233,16 @@ namespace SmartCmdArgs.ViewModel
                 {
                     ToolWindowHistory.SaveState();
                     grp.ProjectConfig = configName;
+                }
+            }, _ => HasSingleSelectedItemOfType<CmdGroup>());
+
+            SetProjectPlatformCommand = new RelayCommand<string>(platformName =>
+            {
+                var selectedItem = TreeViewModel.SelectedItems.FirstOrDefault();
+                if (selectedItem is CmdGroup grp)
+                {
+                    ToolWindowHistory.SaveState();
+                    grp.ProjectPlatform = platformName;
                 }
             }, _ => HasSingleSelectedItemOfType<CmdGroup>());
 
@@ -485,7 +497,7 @@ namespace SmartCmdArgs.ViewModel
                 if (item.Items == null)
                     result = new CmdArgument(item.Id, item.Command, item.Enabled, item.DefaultChecked);
                 else
-                    result = new CmdGroup(item.Id, item.Command, ListEntriesToCmdObjects(item.Items), item.Expanded, item.ExclusiveMode, item.ProjectConfig, item.LaunchProfile, item.Delimiter);
+                    result = new CmdGroup(item.Id, item.Command, ListEntriesToCmdObjects(item.Items), item.Expanded, item.ExclusiveMode, item.ProjectConfig, item.ProjectPlatform, item.LaunchProfile, item.Delimiter);
 
                 result.IsSelected = item.Selected;
                 yield return result;

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/TreeEvents.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/TreeEvents.cs
@@ -93,6 +93,14 @@ namespace SmartCmdArgs.ViewModel
         }
     }
 
+    public class ProjectPlatformChangedEvent : GenericChangedEventArgs<string>
+    {
+        public ProjectPlatformChangedEvent(CmdBase sender, string oldValue, string newValue)
+            : base(sender, oldValue, newValue)
+        {
+        }
+    }
+
     public class LaunchProfileChangedEvent : GenericChangedEventArgs<string>
     {
         public LaunchProfileChangedEvent(CmdBase sender, string oldValue, string newValue)

--- a/SmartCmdArgs/SmartCmdArgs15/SmartCmdArgs15.csproj
+++ b/SmartCmdArgs/SmartCmdArgs15/SmartCmdArgs15.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />

--- a/SmartCmdArgs/SmartCmdArgs16/SmartCmdArgs16.csproj
+++ b/SmartCmdArgs/SmartCmdArgs16/SmartCmdArgs16.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />


### PR DESCRIPTION
This adds a platform filter to the argument group folders that works in much the same way as the existing project configuration filter.