### PR TITLE
Add Custom JSON Root Path Setting

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
@@ -42,6 +42,7 @@ namespace SmartCmdArgs
         private bool _deleteUnnecessaryFilesAutomatically;
 
         private bool _saveSettingsToJson;
+        private bool _useCustomJsonRoot;
         private string _jsonRootPath;
         private bool _vcsSupportEnabled;
         private bool _useSolutionDir;
@@ -95,6 +96,16 @@ namespace SmartCmdArgs
         {
             get => _saveSettingsToJson;
             set => SetAndNotify(value, ref _saveSettingsToJson);
+        }
+
+        [Category("Settings Defaults")]
+        [DisplayName("Save Settings to custom Root path")]
+        [Description("If enabled then the settings configured here are saved to a JSON file within this root path.")]
+        [DefaultValue(false)]
+        public bool UseCustomJsonRoot
+        {
+            get => _useCustomJsonRoot;
+            set => SetAndNotify(value, ref _useCustomJsonRoot);
         }
 
         [Category("Settings Defaults")]

--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
@@ -42,6 +42,7 @@ namespace SmartCmdArgs
         private bool _deleteUnnecessaryFilesAutomatically;
 
         private bool _saveSettingsToJson;
+        private string _jsonRootPath;
         private bool _vcsSupportEnabled;
         private bool _useSolutionDir;
         private bool _macroEvaluationEnabled;
@@ -88,12 +89,22 @@ namespace SmartCmdArgs
 
         [Category("Settings Defaults")]
         [DisplayName("Save Settings to JSON")]
-        [Description("If enabled then the settings configured here are saved to a JSON file next to the Solution.")]
+        [Description("If enabled then the settings configured here are saved to a JSON file.")]
         [DefaultValue(false)]
         public bool SaveSettingsToJson
         {
             get => _saveSettingsToJson;
             set => SetAndNotify(value, ref _saveSettingsToJson);
+        }
+
+        [Category("Settings Defaults")]
+        [DisplayName("JSON Root Path")]
+        [Description("The Root Path to store JSON Settings files. If empty, files will be stored at the same location as the related project file.")]
+        [DefaultValue("")]
+        public string JsonRootPath
+        {
+            get => _jsonRootPath;
+            set => SetAndNotify(value, ref _jsonRootPath);
         }
 
         [Category("Settings Defaults")]

--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
@@ -85,6 +85,7 @@ namespace SmartCmdArgs
         private bool settingsLoaded = false;
 
         public bool SaveSettingsToJson => Settings.SaveSettingsToJson ?? Options.SaveSettingsToJson;
+        public string JsonRootPath => Settings.JsonRootPath == String.Empty ? Options.JsonRootPath : Settings.JsonRootPath;
         public bool IsVcsSupportEnabled => Settings.VcsSupportEnabled ?? Options.VcsSupportEnabled;
         private bool IsMacroEvaluationEnabled => Settings.MacroEvaluationEnabled ?? Options.MacroEvaluationEnabled;
         public bool IsUseSolutionDirEnabled => vsHelper?.GetSolutionFilename() != null && (Settings.UseSolutionDir ?? Options.UseSolutionDir);
@@ -190,6 +191,7 @@ namespace SmartCmdArgs
             switch (e.PropertyName)
             {
                 case nameof(CmdArgsOptionPage.SaveSettingsToJson): SaveSettingsToJsonChanged(); break;
+                case nameof(CmdArgsOptionPage.JsonRootPath): JsonRootPathChanged(); break;
                 case nameof(CmdArgsOptionPage.VcsSupportEnabled): VcsSupportChanged(); break;
                 case nameof(CmdArgsOptionPage.UseSolutionDir): UseSolutionDirChanged(); break;
                 case nameof(CmdArgsOptionPage.UseMonospaceFont): UseMonospaceFontChanged(); break;
@@ -301,7 +303,6 @@ namespace SmartCmdArgs
             switch (Options.RelativePathRoot) {
                 case RelativePathRootOption.BuildTargetDirectory:
                     return MakePathAbsoluteBasedOnTargetDir(path, project, buildConfig);
-                
                 case RelativePathRootOption.ProjectDirectory:
                     return MakePathAbsoluteBasedOnProjectDir(path, project);
 
@@ -767,6 +768,11 @@ namespace SmartCmdArgs
 
         #region OptionPage Events
         private void SaveSettingsToJsonChanged()
+        {
+            SaveSettings();
+        }
+
+        private void JsonRootPathChanged()
         {
             SaveSettings();
         }

--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
@@ -85,7 +85,8 @@ namespace SmartCmdArgs
         private bool settingsLoaded = false;
 
         public bool SaveSettingsToJson => Settings.SaveSettingsToJson ?? Options.SaveSettingsToJson;
-        public string JsonRootPath => Settings.JsonRootPath == String.Empty ? Options.JsonRootPath : Settings.JsonRootPath;
+        public bool UseCustomJsonRoot => Settings.UseCustomJsonRoot ?? Options.UseCustomJsonRoot;
+        public string JsonRootPath => Settings.JsonRootPath ?? Options.JsonRootPath;
         public bool IsVcsSupportEnabled => Settings.VcsSupportEnabled ?? Options.VcsSupportEnabled;
         private bool IsMacroEvaluationEnabled => Settings.MacroEvaluationEnabled ?? Options.MacroEvaluationEnabled;
         public bool IsUseSolutionDirEnabled => vsHelper?.GetSolutionFilename() != null && (Settings.UseSolutionDir ?? Options.UseSolutionDir);
@@ -191,6 +192,7 @@ namespace SmartCmdArgs
             switch (e.PropertyName)
             {
                 case nameof(CmdArgsOptionPage.SaveSettingsToJson): SaveSettingsToJsonChanged(); break;
+                case nameof(CmdArgsOptionPage.UseCustomJsonRoot): UseCustomJsonRootChanged(); break;
                 case nameof(CmdArgsOptionPage.JsonRootPath): JsonRootPathChanged(); break;
                 case nameof(CmdArgsOptionPage.VcsSupportEnabled): VcsSupportChanged(); break;
                 case nameof(CmdArgsOptionPage.UseSolutionDir): UseSolutionDirChanged(); break;
@@ -206,6 +208,8 @@ namespace SmartCmdArgs
             switch (e.PropertyName)
             {
                 case nameof(SettingsViewModel.SaveSettingsToJson): SaveSettingsToJsonChanged(); break;
+                case nameof(SettingsViewModel.UseCustomJsonRoot): UseCustomJsonRootChanged(); break;
+                case nameof(SettingsViewModel.JsonRootPath): JsonRootPathChanged(); break;
                 case nameof(SettingsViewModel.VcsSupportEnabled): VcsSupportChanged(); break;
                 case nameof(SettingsViewModel.UseSolutionDir): UseSolutionDirChanged(); break;
             }
@@ -514,6 +518,8 @@ namespace SmartCmdArgs
             vm.MacroEvaluationEnabled = settings.MacroEvaluationEnabled;
             vm.VcsSupportEnabled = settings.VcsSupportEnabled;
             vm.UseSolutionDir = settings.UseSolutionDir;                    // has to be done after VcsSupportEnabled because it depends on it
+            vm.UseCustomJsonRoot = settings.UseCustomJsonRoot;
+            vm.JsonRootPath = settings.JsonRootPath;
             vm.SaveSettingsToJson = settings.SaveSettingsToJson;            // has to be done at the end because all settings should be correctly set before to be saved to a file
         }
 
@@ -768,6 +774,11 @@ namespace SmartCmdArgs
 
         #region OptionPage Events
         private void SaveSettingsToJsonChanged()
+        {
+            SaveSettings();
+        }
+
+        private void UseCustomJsonRootChanged()
         {
             SaveSettings();
         }

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Logic/FileStorage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Logic/FileStorage.cs
@@ -204,7 +204,7 @@ namespace SmartCmdArgs.Logic
                 fileNames = vsHelper.GetSupportedProjects().Select(FullFilenameForProjectJsonFileFromProject);
             else
                 fileNames = new[] { FullFilenameForSolutionJsonFile() };
-            
+
             foreach (var fileName in fileNames)
             {
                 try
@@ -347,9 +347,15 @@ namespace SmartCmdArgs.Logic
             }
             else
             {
-                return FullFilenameForProjectJsonFileFromProjectPath(project.GetProjectDir(), project.GetName());
+                string jsonDir = project.GetProjectDir();
+                if (cmdPackage.JsonRootPath != String.Empty)
+                {
+                    // Ensure absolute path
+                    jsonDir = Path.GetFullPath(cmdPackage.JsonRootPath);
+                }
+                return FullFilenameForProjectJsonFileFromProjectPath(jsonDir, project.GetName());
             }
-        } 
+        }
 
         private string FullFilenameForSolutionJsonFile()
         {
@@ -357,10 +363,10 @@ namespace SmartCmdArgs.Logic
             return Path.ChangeExtension(slnFilename, "args.json");
         }
 
-        private string FullFilenameForProjectJsonFileFromProjectPath(string projectDir, string projectName)
+        private string FullFilenameForProjectJsonFileFromProjectPath(string jsonDir, string projectName)
         {
             string filename = $"{projectName}.args.json";
-            return Path.Combine(projectDir, filename);
+            return Path.Combine(jsonDir, filename);
         }
 
         private void FireFileStorageChanged(IVsHierarchy project)

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Logic/FileStorage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Logic/FileStorage.cs
@@ -347,11 +347,17 @@ namespace SmartCmdArgs.Logic
             }
             else
             {
-                string jsonDir = project.GetProjectDir();
-                if (cmdPackage.JsonRootPath != String.Empty)
+                string jsonDir = project.GetProjectDir();   
+                if (cmdPackage.UseCustomJsonRoot &&
+                    cmdPackage.JsonRootPath != null &&
+                    cmdPackage.JsonRootPath != String.Empty)
                 {
                     // Ensure absolute path
                     jsonDir = Path.GetFullPath(cmdPackage.JsonRootPath);
+                    string solutionName = Path.GetFileNameWithoutExtension(vsHelper.GetSolutionFilename());
+                    jsonDir = Path.Combine(jsonDir, solutionName);
+                    jsonDir = Path.Combine(jsonDir, project.GetName());
+                    System.IO.Directory.CreateDirectory(jsonDir);
                 }
                 return FullFilenameForProjectJsonFileFromProjectPath(jsonDir, project.GetName());
             }

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Logic/JsonDataObjects.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Logic/JsonDataObjects.cs
@@ -16,6 +16,8 @@ namespace SmartCmdArgs.Logic
     public class SettingsJson
     {
         public bool? SaveSettingsToJson { get; set; }
+        public bool? UseCustomJsonRoot { get; set; }
+        public string JsonRootPath { get; set; }
         public bool? VcsSupportEnabled { get; set; }
         public bool? UseSolutionDir { get; set; }
         public bool? MacroEvaluationEnabled { get; set; }
@@ -25,6 +27,8 @@ namespace SmartCmdArgs.Logic
         public SettingsJson(SettingsViewModel settingsViewModel)
         {
             SaveSettingsToJson = settingsViewModel.SaveSettingsToJson;
+            UseCustomJsonRoot = settingsViewModel.UseCustomJsonRoot;
+            JsonRootPath = settingsViewModel.JsonRootPath;
             VcsSupportEnabled = settingsViewModel.VcsSupportEnabled;
             UseSolutionDir = settingsViewModel.UseSolutionDir;
             MacroEvaluationEnabled = settingsViewModel.MacroEvaluationEnabled;

--- a/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml
@@ -7,7 +7,10 @@
              xmlns:vm="clr-namespace:SmartCmdArgs.ViewModel"
              xmlns:local="clr-namespace:SmartCmdArgs.View"
              mc:Ignorable="d" 
-             d:DesignHeight="370" d:DesignWidth="600" d:DataContext="{x:Type vm:SettingsViewModel}">
+             d:DesignHeight="400" d:DesignWidth="600" d:DataContext="{x:Type vm:SettingsViewModel}">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    </UserControl.Resources>
     <Grid Margin="10,5,10,10">
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"/>
@@ -21,6 +24,13 @@
             <StackPanel VerticalAlignment="Top" HorizontalAlignment="Stretch">
                 <CheckBox Content="Save Settings to JSON" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,5,5,5" FontWeight="Bold" IsChecked="{Binding SaveSettingsToJson}" IsThreeState="True"/>
                 <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled then the settings configured here are saved to a JSON file next to the Solution."/></TextBlock>
+                <CheckBox Visibility="{Binding Path=SaveSettingsToJson, Converter={StaticResource BoolToVisibility}}" Content="Use Custom JSON Root Path" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,5,5,5" FontWeight="Bold" IsChecked="{Binding UseCustomJsonRoot}"/>
+                <TextBlock Visibility="{Binding Path=SaveSettingsToJson, Converter={StaticResource BoolToVisibility}}" Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled then the settings configured here are saved to a JSON file next to the Solution."/></TextBlock>
+                <TextBlock Visibility="{Binding Path=UseCustomJsonRoot, Converter={StaticResource BoolToVisibility}}" Margin="5,5,5,0" TextWrapping="WrapWithOverflow" FontWeight="Bold"><Run Text="Root Path of where to save Json Settings"/></TextBlock>
+                <StackPanel Visibility="{Binding Path=UseCustomJsonRoot, Converter={StaticResource BoolToVisibility}}" Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBox Name="JsonRootPathTextbox" IsEnabled="False" Visibility="{Binding Path=UseCustomJsonRoot, Converter={StaticResource BoolToVisibility}}" Text="{Binding JsonRootPath}" Width="445" Margin="5,5,5,5"/>
+                    <Button Name="BtnOpen" Margin="0,5,5,5" Padding="2,2" Content="Open" Click="BtnOpen_Click"/>
+                </StackPanel>
                 <CheckBox Content="Enable version control support" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,5,5,5" FontWeight="Bold" IsChecked="{Binding VcsSupportEnabled}" IsThreeState="True"/>
                 <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled the extension will store the command line arguments into an json file at the same loctation as the related project file. That way the command line arguments might be version controlled by a VCS. If disabled the extension will store everything inside the solutions .suo-file which is usally ignored by version control. The default value for this setting is True."/></TextBlock>
                 <CheckBox Content="Use Solution Directory" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding UseSolutionDir}" IsEnabled="{Binding VcsSupportEnabled, Mode=OneWay}" IsThreeState="True"/>

--- a/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using System.ComponentModel;
+using SmartCmdArgs.ViewModel;
 
 namespace SmartCmdArgs.View
 {
@@ -44,6 +45,17 @@ namespace SmartCmdArgs.View
             Window parentWindow = Window.GetWindow(this);
             parentWindow.DialogResult = true;
             parentWindow.Close();
+        }
+
+        private void BtnOpen_Click(object sender, RoutedEventArgs e)
+        {
+            System.Windows.Forms.FolderBrowserDialog folderBrowser = new System.Windows.Forms.FolderBrowserDialog();
+            var result = folderBrowser.ShowDialog();
+            if (result == System.Windows.Forms.DialogResult.OK)
+            {
+                SettingsViewModel settings = this.DataContext as SettingsViewModel;
+                settings.JsonRootPath = folderBrowser.SelectedPath;
+            }
         }
     }
 }

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
@@ -15,6 +15,7 @@ namespace SmartCmdArgs.ViewModel
         private CmdArgsPackage _package;
 
         private bool? _saveSettingsToJson;
+        private string _jsonRootPath;
         private bool? _vcsSupportEnabled;
         private bool? _useSolutionDir;
         private bool? _macroEvaluationEnabled;
@@ -23,6 +24,12 @@ namespace SmartCmdArgs.ViewModel
         {
             get => _saveSettingsToJson;
             set => SetAndNotify(value, ref _saveSettingsToJson);
+        }
+
+        public string JsonRootPath
+        {
+            get => _jsonRootPath;
+            set => SetAndNotify(value, ref _jsonRootPath);
         }
 
         public bool? VcsSupportEnabled

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
@@ -15,6 +15,7 @@ namespace SmartCmdArgs.ViewModel
         private CmdArgsPackage _package;
 
         private bool? _saveSettingsToJson;
+        private bool? _useCustomJsonRoot;
         private string _jsonRootPath;
         private bool? _vcsSupportEnabled;
         private bool? _useSolutionDir;
@@ -24,6 +25,12 @@ namespace SmartCmdArgs.ViewModel
         {
             get => _saveSettingsToJson;
             set => SetAndNotify(value, ref _saveSettingsToJson);
+        }
+
+        public bool? UseCustomJsonRoot
+        {
+            get => _useCustomJsonRoot;
+            set => SetAndNotify(value, ref _useCustomJsonRoot);
         }
 
         public string JsonRootPath

--- a/SmartCmdArgs/SmartCmdArgs17/SmartCmdArgs17.csproj
+++ b/SmartCmdArgs/SmartCmdArgs17/SmartCmdArgs17.csproj
@@ -79,7 +79,10 @@
       <Version>2.0.6142705</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5233" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4065">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="..\SharedResources\CmdArgsPackage.vsct">


### PR DESCRIPTION
(Rebased onto master from #145, feature/vs2022/json-root-path)

This feature implements behavior for allowing a user to specify a custom root path for all JSON settings for each project. This works by allowing the user to specify the Root path, and the Solution name and Project names are added to the path.

This allows for saving modified Command Line arguments in a Source Control solution, while having an ephemeral Visual Studio project (such as the case when the VS projects are generated by a build system). Due to this, this resolves issue https://github.com/MBulli/SmartCommandlineArgs/issues/115

* Adds settings for "Use Custom JSON Root" and "Custom JSON Root"
* These options are hidden unless the "Save JSON Settings" setting is true.

A description of how we would plan to use this in practice would be something like:

1. Have our build system generate a SolutionName.ArgsCfg.json that includes an entry for the Custom JSON Root, which is known by the build system
2. The Custom Json Root folder will be checked into source control, allowing development teams to add useful sets of command line arguments. These changes, since they're directly pointing from Extension to the custom path, will allow devs to save and commit JSON modifications