### PR TITLE
CPS project custom in memory profiles (avoid overriding project json), enable disable extension option, show global settings on settings panel

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <activePackageSource>
+        <add key="All" value="(Aggregate source)" />
+    </activePackageSource>
+  <packageSources>
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
@@ -45,6 +45,8 @@ namespace SmartCmdArgs
         private bool _vcsSupportEnabled;
         private bool _useSolutionDir;
         private bool _macroEvaluationEnabled;
+		private bool _CPSCustomProjectEnabled;
+		private bool _WeAreEnabled;
 
         [Category("General")]
         [DisplayName("Relative path root")]
@@ -125,6 +127,26 @@ namespace SmartCmdArgs
             get => _macroEvaluationEnabled;
             set => SetAndNotify(value, ref _macroEvaluationEnabled);
         }
+
+		[Category("Settings Defaults")]
+        [DisplayName("Enable This Extension")]
+        [Description("If not enabled then it will not have any effect when running.")]
+        [DefaultValue(true)]
+		public bool WeAreEnabled {
+			get => _WeAreEnabled;
+			set => SetAndNotify(value, ref _WeAreEnabled);
+		}
+
+
+		[Category("Settings Defaults")]
+        [DisplayName("CPS Custom Project Profile")]
+        [Description("If enabled CPS style projects will have an additional in memory 'Smart CLI Command' profile added, and our custom args will only run when its selected rather than overriding the active profile.")]
+        [DefaultValue(false)]
+		public bool CPSCustomProjectEnabled {
+			get => _CPSCustomProjectEnabled;
+			set => SetAndNotify(value, ref _CPSCustomProjectEnabled);
+		}
+		
 
         public override void SaveSettingsToStorage()
         {

--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
@@ -87,6 +87,8 @@ namespace SmartCmdArgs
         public bool SaveSettingsToJson => Settings.SaveSettingsToJson ?? Options.SaveSettingsToJson;
         public bool IsVcsSupportEnabled => Settings.VcsSupportEnabled ?? Options.VcsSupportEnabled;
         private bool IsMacroEvaluationEnabled => Settings.MacroEvaluationEnabled ?? Options.MacroEvaluationEnabled;
+		public bool AreWeEnabled => Settings.WeAreEnabled ?? Options.WeAreEnabled;
+		public bool CPSCustomProjectEnabled => Settings.CPSCustomProjectEnabled ?? Options.CPSCustomProjectEnabled;
         public bool IsUseSolutionDirEnabled => vsHelper?.GetSolutionFilename() != null && (Settings.UseSolutionDir ?? Options.UseSolutionDir);
 
         private bool IsUseMonospaceFontEnabled => Options.UseMonospaceFont;
@@ -282,7 +284,7 @@ namespace SmartCmdArgs
             if (commandLineArgs == null)
                 return;
 
-            ProjectArguments.SetArguments(project, commandLineArgs);
+            ProjectArguments.SetArguments(project, commandLineArgs, CPSCustomProjectEnabled);
             Logger.Info($"Updated Configuration for Project: {project.GetName()}");
         }
 
@@ -710,6 +712,8 @@ namespace SmartCmdArgs
 
         private void VsHelper_ProjectWillRun(object sender, EventArgs e)
         {
+			if (!AreWeEnabled)
+				return;
             Logger.Info("VS-Event: Startup project will run.");
 
             foreach (var startupProject in ToolWindowViewModel.TreeViewModel.StartupProjects)

--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // <copyright file="CmdArgsPackage.cs" company="Company">
 //     Copyright (c) Company.  All rights reserved.
 // </copyright>
@@ -86,12 +86,12 @@ namespace SmartCmdArgs
 
         public bool SaveSettingsToJson => Settings.SaveSettingsToJson ?? Options.SaveSettingsToJson;
         public bool IsVcsSupportEnabled => Settings.VcsSupportEnabled ?? Options.VcsSupportEnabled;
-        private bool IsMacroEvaluationEnabled => Settings.MacroEvaluationEnabled ?? Options.MacroEvaluationEnabled;
+        public bool IsMacroEvaluationEnabled => Settings.MacroEvaluationEnabled ?? Options.MacroEvaluationEnabled;
 		public bool AreWeEnabled => Settings.WeAreEnabled ?? Options.WeAreEnabled;
 		public bool CPSCustomProjectEnabled => Settings.CPSCustomProjectEnabled ?? Options.CPSCustomProjectEnabled;
         public bool IsUseSolutionDirEnabled => vsHelper?.GetSolutionFilename() != null && (Settings.UseSolutionDir ?? Options.UseSolutionDir);
 
-        private bool IsUseMonospaceFontEnabled => Options.UseMonospaceFont;
+        public bool IsUseMonospaceFontEnabled => Options.UseMonospaceFont;
         public bool DeleteEmptyFilesAutomatically => Options.DeleteEmptyFilesAutomatically;
         public bool DeleteUnnecessaryFilesAutomatically => Options.DeleteUnnecessaryFilesAutomatically;
 
@@ -516,6 +516,8 @@ namespace SmartCmdArgs
             vm.VcsSupportEnabled = settings.VcsSupportEnabled;
             vm.UseSolutionDir = settings.UseSolutionDir;                    // has to be done after VcsSupportEnabled because it depends on it
             vm.SaveSettingsToJson = settings.SaveSettingsToJson;            // has to be done at the end because all settings should be correctly set before to be saved to a file
+			vm.CPSCustomProjectEnabled = settings.CPSCustomProjectEnabled;
+			vm.WeAreEnabled = settings.WeAreEnabled;
         }
 
         private void UpdateCommandsForProject(IVsHierarchy project)

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Helper/ProjectArguments.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Helper/ProjectArguments.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -249,11 +249,11 @@ namespace SmartCmdArgs.Helper
 
         #region Common Project System (CPS)
 
-        private static void SetCpsProjectArguments(EnvDTE.Project project, string arguments)
+        private static void SetCpsProjectArguments(EnvDTE.Project project, string arguments, bool cpsUseCustomProfile)
         {
             // Should only be called in VS 2017 or higher
             // .Net Core 2 is not supported by VS 2015, so this should not cause problems
-            CpsProjectSupport.SetCpsProjectArguments(project, arguments);
+            CpsProjectSupport.SetCpsProjectArguments(project, arguments, cpsUseCustomProfile);
         }
 
         private static void GetCpsProjectAllArguments(EnvDTE.Project project, List<CmdArgumentJson> allArgs)
@@ -302,7 +302,7 @@ namespace SmartCmdArgs.Helper
             } },
             // C# - Lagacy DotNetCore
             {ProjectKinds.CSCore, new ProjectArgumentsHandlers() {
-                SetArguments = (project, arguments) => SetCpsProjectArguments(project, arguments),
+                SetArguments = (project, arguments) => SetCpsProjectArguments(project, arguments,false),
                 GetAllArguments = (project, allArgs) => GetCpsProjectAllArguments(project, allArgs)
             } },
             // F#
@@ -356,12 +356,12 @@ namespace SmartCmdArgs.Helper
             }
         }
 
-        public static void SetArguments(IVsHierarchy project, string arguments)
+        public static void SetArguments(IVsHierarchy project, string arguments, bool CpsUseCustomProfile=false)
         {
             if (project.IsCpsProject())
             {
                 Logger.Info($"Setting arguments on CPS project of type '{project.GetKind()}'.");
-                SetCpsProjectArguments(project.GetProject(), arguments);
+                SetCpsProjectArguments(project.GetProject(), arguments,CpsUseCustomProfile);
             }
             else
             {

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Logic/JsonDataObjects.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Logic/JsonDataObjects.cs
@@ -19,6 +19,8 @@ namespace SmartCmdArgs.Logic
         public bool? VcsSupportEnabled { get; set; }
         public bool? UseSolutionDir { get; set; }
         public bool? MacroEvaluationEnabled { get; set; }
+		public bool? CPSCustomProjectEnabled { get; set; }
+		public bool? WeAreEnabled { get; set; }
 
         public SettingsJson() { }
 
@@ -28,6 +30,8 @@ namespace SmartCmdArgs.Logic
             VcsSupportEnabled = settingsViewModel.VcsSupportEnabled;
             UseSolutionDir = settingsViewModel.UseSolutionDir;
             MacroEvaluationEnabled = settingsViewModel.MacroEvaluationEnabled;
+			CPSCustomProjectEnabled = settingsViewModel.CPSCustomProjectEnabled;
+			WeAreEnabled = settingsViewModel.WeAreEnabled;
         }
     }
 

--- a/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="SmartCmdArgs.View.SettingsControl"
+<UserControl x:Class="SmartCmdArgs.View.SettingsControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -21,13 +21,13 @@
         <ScrollViewer Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto">
             <StackPanel VerticalAlignment="Top" HorizontalAlignment="Stretch">
                 <CheckBox Content="Save Settings to JSON" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,5,5,5" FontWeight="Bold" IsChecked="{Binding SaveSettingsToJson}" IsThreeState="True"/>
-                <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled then the settings configured here are saved to a JSON file next to the Solution."/></TextBlock>
+				<TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow">(<Run Text="{Binding Package.SaveSettingsToJson, Mode=OneWay}" />) <Run Text="If enabled then the settings configured here are saved to a JSON file next to the Solution."/></TextBlock>
                 <CheckBox Content="Enable version control support" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,5,5,5" FontWeight="Bold" IsChecked="{Binding VcsSupportEnabled}" IsThreeState="True"/>
-                <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled the extension will store the command line arguments into an json file at the same loctation as the related project file. That way the command line arguments might be version controlled by a VCS. If disabled the extension will store everything inside the solutions .suo-file which is usally ignored by version control. The default value for this setting is True."/></TextBlock>
+				<TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow">(<Run Text="{Binding Package.IsVcsSupportEnabled, Mode=OneWay}" />) <Run Text="If enabled the extension will store the command line arguments into an json file at the same loctation as the related project file. That way the command line arguments might be version controlled by a VCS. If disabled the extension will store everything inside the solutions .suo-file which is usally ignored by version control. The default value for this setting is True."/></TextBlock>
                 <CheckBox Content="Use Solution Directory" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding UseSolutionDir}" IsEnabled="{Binding VcsSupportEnabled, Mode=OneWay}" IsThreeState="True"/>
-                <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow" IsEnabled="{Binding VcsSupportEnabled, Mode=OneWay}"><Run Text="If enabled all arguments of every project will be stored in a single file next to the *.sln file. (Only if version control support is enabled)"/></TextBlock>
+				<TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow" IsEnabled="{Binding VcsSupportEnabled, Mode=OneWay}">(<Run Text="{Binding Package.IsUseSolutionDirEnabled, Mode=OneWay}" />) <Run Text="If enabled all arguments of every project will be stored in a single file next to the *.sln file. (Only if version control support is enabled)"/></TextBlock>
                 <CheckBox Content="Enable Macro evaluation" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding MacroEvaluationEnabled}" IsThreeState="True"/>
-                <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled Macros like '$(ProjectDir)' will be evaluated and replaced by the corresponding string."/></TextBlock>
+				<TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow">(<Run Text="{Binding Package.IsMacroEvaluationEnabled, Mode=OneWay}" />) <Run Text="If enabled Macros like '$(ProjectDir)' will be evaluated and replaced by the corresponding string."/></TextBlock>
 				<CheckBox Content="Custom CPS Project Profile" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding CPSCustomProjectEnabled}" IsThreeState="True"/>
 				<TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow">(<Run Text="{Binding Package.CPSCustomProjectEnabled, Mode=OneWay}" />) <Run Text="If enabled CPS style projects will have an additional in memory 'Smart CLI Command' profile added, and our custom args will only run when its selected rather than overriding the active profile."/></TextBlock>
             </StackPanel>

--- a/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml
@@ -16,6 +16,7 @@
             <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
         <Label Grid.Row="0" Content="Smart Commandline Arguments Settings" FontSize="20" VerticalAlignment="Top" HorizontalAlignment="Stretch"/>
+		<CheckBox Content="Enabled"  HorizontalAlignment="Right" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding WeAreEnabled}" IsThreeState="True"/>
         <TextBlock Grid.Row="1" TextWrapping="WrapWithOverflow" Margin="5,0,0,5">Default values can be configured under <Hyperlink Command="{Binding OpenOptionsCommand}">Tools → Options → Smart Commandline Arguments</Hyperlink></TextBlock>
         <ScrollViewer Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto">
             <StackPanel VerticalAlignment="Top" HorizontalAlignment="Stretch">
@@ -27,6 +28,8 @@
                 <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow" IsEnabled="{Binding VcsSupportEnabled, Mode=OneWay}"><Run Text="If enabled all arguments of every project will be stored in a single file next to the *.sln file. (Only if version control support is enabled)"/></TextBlock>
                 <CheckBox Content="Enable Macro evaluation" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding MacroEvaluationEnabled}" IsThreeState="True"/>
                 <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled Macros like '$(ProjectDir)' will be evaluated and replaced by the corresponding string."/></TextBlock>
+				<CheckBox Content="Custom CPS Project Profile" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding CPSCustomProjectEnabled}" IsThreeState="True"/>
+				<TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow">(<Run Text="{Binding Package.CPSCustomProjectEnabled, Mode=OneWay}" />) <Run Text="If enabled CPS style projects will have an additional in memory 'Smart CLI Command' profile added, and our custom args will only run when its selected rather than overriding the active profile."/></TextBlock>
             </StackPanel>
         </ScrollViewer>
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,5,0,0">

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
@@ -18,6 +18,8 @@ namespace SmartCmdArgs.ViewModel
         private bool? _vcsSupportEnabled;
         private bool? _useSolutionDir;
         private bool? _macroEvaluationEnabled;
+		private bool? _WeAreEnabled;
+		private bool? _CPSCustomProjectEnabled;
 
         public bool? SaveSettingsToJson
         {
@@ -43,6 +45,15 @@ namespace SmartCmdArgs.ViewModel
             set => SetAndNotify(value, ref _macroEvaluationEnabled);
         }
 
+		public bool? WeAreEnabled {
+			get => _WeAreEnabled;
+			set => SetAndNotify(value, ref _WeAreEnabled);
+		}
+
+		public bool? CPSCustomProjectEnabled {
+			get => _CPSCustomProjectEnabled;
+			set => SetAndNotify(value, ref _CPSCustomProjectEnabled);
+		}
         public RelayCommand OpenOptionsCommand { get; }
 
         public SettingsViewModel(CmdArgsPackage package)

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
@@ -55,6 +55,7 @@ namespace SmartCmdArgs.ViewModel
 			set => SetAndNotify(value, ref _CPSCustomProjectEnabled);
 		}
         public RelayCommand OpenOptionsCommand { get; }
+		public CmdArgsPackage Package => _package;
 
         public SettingsViewModel(CmdArgsPackage package)
         {

--- a/SmartCmdArgs/SmartCmdArgs17/SmartCmdArgs17.csproj
+++ b/SmartCmdArgs/SmartCmdArgs17/SmartCmdArgs17.csproj
@@ -73,10 +73,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
-      <Version>15.8.243</Version>
+      <Version>17.2.402-pre</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed">
-      <Version>2.0.6142705</Version>
+      <Version>17.5.3-gbf0428edc0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5233" />


### PR DESCRIPTION
So if there is desire for any of these features I can split the PR up into multiple, for now I just have the 3 features as separate commits.

The big addition is the CPS custom profile support.   The current behavior is when changing anything in SCA it overrides the settings in the active profile.   If you are working on a project with others this may not be desired.  This adds (an off by default) option to use a separate profile just for us.   This profile is only kept in memory, so wont change the launchSettings.json.   If you have this enabled, it will only use SCA features when you have the custom SCA profile selected.  This is except the first time after start where it will always select the SCA profile by default.    This may want to be tweaked, IE adding our profile before they go to debug, automatically selecting our profile if they change something in SCA, etc.  The nice part though is you can use other existing launch profiles and SCA side by side and SCA will not consistently destroy your active profile with it enabled.   

Second decent feature is the Enable / disable extension checkbox.   I know previously this was declined but I think it should be reconsidered.  It sounds like just closing the window should disable it but I have found even closed when I start a project it would still override the existing profile.  Even if it did work though I think users may not want to change their layout back and forth to control if its enabled.    The checkbox as fast and quick to access.

Finally, the least polished, on the settings page I added the global settings.  Right now the 3 state checkboxes are great, except you don't know  what the global setting is currently.  This adds it to the description line.  if this is wanted can refine (maybe move up next to the checkbox or explain in more detail).
