### PR TITLE
Fix invalid paths in args from throwing uncaught exceptions

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
@@ -331,25 +331,33 @@ namespace SmartCmdArgs
 
         public string MakePathAbsolute(string path, string baseDir)
         {
-            var drive = Path.GetPathRoot(path);
-
-            if (!Path.IsPathRooted(path))
+            try
             {
-                if (baseDir == null)
-                    return null;
+                var drive = Path.GetPathRoot(path);
 
-                path = Path.Combine(baseDir, path);
+                if (!Path.IsPathRooted(path))
+                {
+                    if (baseDir == null)
+                        return null;
+
+                    path = Path.Combine(baseDir, path);
+                }
+                else if (drive == "\\")
+                {
+                    if (baseDir == null)
+                        return null;
+
+                    var baseDrive = Path.GetPathRoot(baseDir);
+                    path = Path.Combine(baseDrive, path.Substring(1));
+                }
+
+                return Path.GetFullPath(path);
             }
-            else if (drive == "\\")
+            catch(Exception)
             {
-                if (baseDir == null)
-                    return null;
-
-                var baseDrive = Path.GetPathRoot(baseDir);
-                path = Path.Combine(baseDrive, path.Substring(1));
+                return path;
             }
-
-            return Path.GetFullPath(path);
+                
         }
 
         public string EvaluateMacros(string arg, IVsHierarchy project)


### PR DESCRIPTION
Closes #148

While we do check for invalid path characters a path is not necessarily only invalid because of a character, but the order in which the chars appear.  Enter a url like https://google.com for example:)    all are valid in a path but :// is not valid together.

I didn't return null as logically if this function is used for anything else returning the input would probably be expected.   I do not believe there is a risk of File.Exists or Directory.Exists throwing an  exception as long as the string doesn't contain invalid chars (but order invalid is allowed).   The few exceptions I tested it seemed those handled it fine so we didn't need to wrap them too.