### PR TITLE
CPS Custom In Memory Profile option

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <activePackageSource>
+        <add key="All" value="(Aggregate source)" />
+    </activePackageSource>
+  <packageSources>
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
@@ -45,6 +45,7 @@ namespace SmartCmdArgs
         private bool _vcsSupportEnabled;
         private bool _useSolutionDir;
         private bool _macroEvaluationEnabled;
+		private bool _CPSCustomProjectEnabled;
 
         [Category("General")]
         [DisplayName("Relative path root")]
@@ -125,6 +126,18 @@ namespace SmartCmdArgs
             get => _macroEvaluationEnabled;
             set => SetAndNotify(value, ref _macroEvaluationEnabled);
         }
+
+
+
+		[Category("Settings Defaults")]
+        [DisplayName("CPS Custom Project Profile")]
+        [Description("If enabled CPS style projects will have an additional in memory 'Smart CLI Command' profile added, and our custom args will only run when its selected rather than overriding the active profile.")]
+        [DefaultValue(false)]
+		public bool CPSCustomProjectEnabled {
+			get => _CPSCustomProjectEnabled;
+			set => SetAndNotify(value, ref _CPSCustomProjectEnabled);
+		}
+		
 
         public override void SaveSettingsToStorage()
         {

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Helper/CpsProjectSupport.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Helper/CpsProjectSupport.cs
@@ -53,6 +53,7 @@ namespace SmartCmdArgs.Helper
             }
             return null;
         }
+        public static bool IsActiveLaunchProfileCustomProfile(EnvDTE.Project project) => GetActiveLaunchProfileName(project) == WritableLaunchProfile.CustomProfileName;
 
         public static IEnumerable<string> GetLaunchProfileNames(EnvDTE.Project project)
         {
@@ -63,8 +64,12 @@ namespace SmartCmdArgs.Helper
             }
             return null;
         }
+        public static void EnsureCustomProfileCreated(EnvDTE.Project project, bool SetActive)
+        {
+            SetCpsProjectArguments(project, "", true, SetActive);
+        }
 
-        public static void SetCpsProjectArguments(EnvDTE.Project project, string arguments)
+        public static void SetCpsProjectArguments(EnvDTE.Project project, string arguments, bool cpsUseCustomProfile, bool setActive = false)
         {
             IUnconfiguredProjectServices unconfiguredProjectServices;
             IProjectServices projectServices;
@@ -77,7 +82,7 @@ namespace SmartCmdArgs.Helper
                 if (activeLaunchProfile == null)
                     return;
 
-                WritableLaunchProfile writableLaunchProfile = new WritableLaunchProfile(activeLaunchProfile);
+                WritableLaunchProfile writableLaunchProfile = new WritableLaunchProfile(activeLaunchProfile, cpsUseCustomProfile);
                 writableLaunchProfile.CommandLineArgs = arguments;
 
                 // Does not work on VS2015, which should be okay ...
@@ -85,7 +90,11 @@ namespace SmartCmdArgs.Helper
                 IProjectThreadingService projectThreadingService = projectServices.ThreadingPolicy;
                 projectThreadingService.ExecuteSynchronously(() =>
                 {
-                    return launchSettingsProvider.AddOrUpdateProfileAsync(writableLaunchProfile, addToFront: false);
+                    var tsk = launchSettingsProvider.AddOrUpdateProfileAsync(writableLaunchProfile, addToFront: false);
+                    if (setActive)
+                        tsk = tsk.ContinueWith(_ => launchSettingsProvider.SetActiveProfileAsync(writableLaunchProfile.Name));
+
+                    return tsk;
                 });
             }
         }
@@ -117,6 +126,9 @@ namespace SmartCmdArgs.Helper
     }
 
     class WritableLaunchProfile : ILaunchProfile
+#if VS17
+        , Microsoft.VisualStudio.ProjectSystem.Debug.IPersistOption
+#endif
     {
         public string Name { set; get; }
         public string CommandName { set; get; }
@@ -127,13 +139,27 @@ namespace SmartCmdArgs.Helper
         public string LaunchUrl { set; get; }
         public ImmutableDictionary<string, string> EnvironmentVariables { set; get; }
         public ImmutableDictionary<string, object> OtherSettings { set; get; }
+        public bool DoNotPersist { get; set; }
 
-        public WritableLaunchProfile(ILaunchProfile launchProfile)
+        public const string CustomProfileName = "Smart CLI Args";
+        public WritableLaunchProfile(ILaunchProfile launchProfile, bool cpsUseCustomProfile)
         {
-            Name = launchProfile.Name;
+            if (!cpsUseCustomProfile)
+            {
+                Name = launchProfile.Name;
+                CommandLineArgs = launchProfile.CommandLineArgs;
+            } else
+            {
+                Name = CustomProfileName;
+                DoNotPersist = true;
+                if (launchProfile.Name == CustomProfileName)
+                    CommandLineArgs = launchProfile.CommandLineArgs;
+                else
+                    CommandLineArgs = "";//ensure we dont get into an odd state where hidden args are being applied
+
+            }
             ExecutablePath = launchProfile.ExecutablePath;
             CommandName = launchProfile.CommandName;
-            CommandLineArgs = launchProfile.CommandLineArgs;
             WorkingDirectory = launchProfile.WorkingDirectory;
             LaunchBrowser = launchProfile.LaunchBrowser;
             LaunchUrl = launchProfile.LaunchUrl;

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Helper/ProjectArguments.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Helper/ProjectArguments.cs
@@ -249,11 +249,11 @@ namespace SmartCmdArgs.Helper
 
         #region Common Project System (CPS)
 
-        private static void SetCpsProjectArguments(EnvDTE.Project project, string arguments)
+        private static void SetCpsProjectArguments(EnvDTE.Project project, string arguments, bool cpsUseCustomProfile)
         {
             // Should only be called in VS 2017 or higher
             // .Net Core 2 is not supported by VS 2015, so this should not cause problems
-            CpsProjectSupport.SetCpsProjectArguments(project, arguments);
+            CpsProjectSupport.SetCpsProjectArguments(project, arguments, cpsUseCustomProfile);
         }
 
         private static void GetCpsProjectAllArguments(EnvDTE.Project project, List<CmdArgumentJson> allArgs)
@@ -302,7 +302,7 @@ namespace SmartCmdArgs.Helper
             } },
             // C# - Lagacy DotNetCore
             {ProjectKinds.CSCore, new ProjectArgumentsHandlers() {
-                SetArguments = (project, arguments) => SetCpsProjectArguments(project, arguments),
+                SetArguments = (project, arguments) => SetCpsProjectArguments(project, arguments, false),
                 GetAllArguments = (project, allArgs) => GetCpsProjectAllArguments(project, allArgs)
             } },
             // F#
@@ -356,12 +356,12 @@ namespace SmartCmdArgs.Helper
             }
         }
 
-        public static void SetArguments(IVsHierarchy project, string arguments)
+        public static void SetArguments(IVsHierarchy project, string arguments, bool CpsUseCustomProfile=false)
         {
             if (project.IsCpsProject())
             {
                 Logger.Info($"Setting arguments on CPS project of type '{project.GetKind()}'.");
-                SetCpsProjectArguments(project.GetProject(), arguments);
+                SetCpsProjectArguments(project.GetProject(), arguments, CpsUseCustomProfile);
             }
             else
             {

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Logic/JsonDataObjects.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Logic/JsonDataObjects.cs
@@ -19,6 +19,7 @@ namespace SmartCmdArgs.Logic
         public bool? VcsSupportEnabled { get; set; }
         public bool? UseSolutionDir { get; set; }
         public bool? MacroEvaluationEnabled { get; set; }
+		public bool? CPSCustomProjectEnabled { get; set; }
 
         public SettingsJson() { }
 
@@ -28,6 +29,7 @@ namespace SmartCmdArgs.Logic
             VcsSupportEnabled = settingsViewModel.VcsSupportEnabled;
             UseSolutionDir = settingsViewModel.UseSolutionDir;
             MacroEvaluationEnabled = settingsViewModel.MacroEvaluationEnabled;
+			CPSCustomProjectEnabled = settingsViewModel.CPSCustomProjectEnabled;
         }
     }
 

--- a/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/View/SettingsControl.xaml
@@ -27,6 +27,10 @@
                 <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow" IsEnabled="{Binding VcsSupportEnabled, Mode=OneWay}"><Run Text="If enabled all arguments of every project will be stored in a single file next to the *.sln file. (Only if version control support is enabled)"/></TextBlock>
                 <CheckBox Content="Enable Macro evaluation" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding MacroEvaluationEnabled}" IsThreeState="True"/>
                 <TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled Macros like '$(ProjectDir)' will be evaluated and replaced by the corresponding string."/></TextBlock>
+                <CheckBox HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,10,5,5" FontWeight="Bold" IsChecked="{Binding CPSCustomProjectEnabled}" IsThreeState="True">
+                    <TextBlock>Custom CPS Project Profile (<Run Text="{Binding Package.CPSCustomProjectEnabled, Mode=OneWay}" />)</TextBlock>
+                </CheckBox>
+				<TextBlock Margin="15,0,10,5" TextWrapping="WrapWithOverflow"><Run Text="If enabled CPS style projects will have an additional in memory 'Smart CLI Command' profile added, and our custom args will only run when its selected rather than overriding the active profile."/></TextBlock>
             </StackPanel>
         </ScrollViewer>
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,5,0,0">

--- a/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/ViewModel/SettingsViewModel.cs
@@ -18,6 +18,7 @@ namespace SmartCmdArgs.ViewModel
         private bool? _vcsSupportEnabled;
         private bool? _useSolutionDir;
         private bool? _macroEvaluationEnabled;
+        private bool? _CPSCustomProjectEnabled;
 
         public bool? SaveSettingsToJson
         {
@@ -43,6 +44,12 @@ namespace SmartCmdArgs.ViewModel
             set => SetAndNotify(value, ref _macroEvaluationEnabled);
         }
 
+
+        public bool? CPSCustomProjectEnabled
+        {
+            get => _CPSCustomProjectEnabled;
+            set => SetAndNotify(value, ref _CPSCustomProjectEnabled);
+        }
         public RelayCommand OpenOptionsCommand { get; }
 
         public SettingsViewModel(CmdArgsPackage package)

--- a/SmartCmdArgs/SmartCmdArgs17/SmartCmdArgs17.csproj
+++ b/SmartCmdArgs/SmartCmdArgs17/SmartCmdArgs17.csproj
@@ -73,10 +73,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
-      <Version>15.8.243</Version>
+      <Version>17.2.402-pre</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed">
-      <Version>2.0.6142705</Version>
+      <Version>17.5.3-gbf0428edc0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5233" />


### PR DESCRIPTION
Mostly the same as #147
Some additional logic added to avoid creating the profile / setting it active unless a true user action or on startup project changed when we have at least one command arg in the CLI window (doesn't care if that arg is enabled or not).

Note option added to option page in style of new format from #150, if merged before #150 will not look correct.

Removed the enable/disable plugin option will wait to hear on comments in #147 and then will do a separate PR.