### PR TITLE
Add VSConstants.VSStd97CmdID.StepInto

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs.Shared/VisualStudioHelper.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/VisualStudioHelper.cs
@@ -450,6 +450,7 @@ namespace SmartCmdArgs
                     case VSConstants.VSStd97CmdID.Start:
                     case VSConstants.VSStd97CmdID.StartNoDebug:
                     case VSConstants.VSStd97CmdID.Restart:
+                    case VSConstants.VSStd97CmdID.StepInto:
                         ProjectBeforeRun?.Invoke(this, EventArgs.Empty);
                         break;
                 }


### PR DESCRIPTION
This fixes https://github.com/MBulli/SmartCommandlineArgs/issues/165 (Starting debug with "step into" doesn't update command line arguments)