### PR TITLE
Reimplementation of in memory profile support

### DIFF
--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsOptionPage.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell;
 using SmartCmdArgs.Helper;
 using System.ComponentModel;
 using System.Linq;
@@ -78,6 +78,7 @@ namespace SmartCmdArgs
         private bool _manageWorkingDirectories;
         private bool _manageLaunchApplication;
         private bool _vcsSupportEnabled;
+        private bool _useCpsVirtualProfile;
         private bool _useSolutionDir;
         private bool _macroEvaluationEnabled;
 
@@ -110,6 +111,7 @@ namespace SmartCmdArgs
             get => _useMonospaceFont;
             set => SetAndNotify(value, ref _useMonospaceFont);
         }
+
 
         [Category("Appearance")]
         [DisplayName("Display Tags for CLAs")]
@@ -199,6 +201,16 @@ namespace SmartCmdArgs
         {
             get => _vcsSupportEnabled;
             set => SetAndNotify(value, ref _vcsSupportEnabled);
+        }
+
+         [Category("Settings Defaults")]
+        [DisplayName("Use CPS Virtual Profile")]
+        [Description("If enabled a virtual profile is created for CPS projects and only this profile is changed by the extension.")]
+        [DefaultValue(false)]
+        public bool UseCpsVirtualProfile
+        {
+            get => _useCpsVirtualProfile;
+            set => SetAndNotify(value, ref _useCpsVirtualProfile);
         }
 
         [Category("Settings Defaults")]

--- a/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/CmdArgsPackage.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // <copyright file="CmdArgsPackage.cs" company="Company">
 //     Copyright (c) Company.  All rights reserved.
 // </copyright>
@@ -69,6 +69,7 @@ namespace SmartCmdArgs
         private ILifeCycleService lifeCycleService;
         private IVsEventHandlingService vsEventHandling;
         private IFileStorageEventHandlingService fileStorageEventHandling;
+        private ICpsProjectConfigService cpsProjectConfigService;
 
         private ToolWindowViewModel toolWindowViewModel;
         private TreeViewModel treeViewModel;
@@ -105,6 +106,7 @@ namespace SmartCmdArgs
             lifeCycleService = ServiceProvider.GetRequiredService<ILifeCycleService>();
             vsEventHandling = ServiceProvider.GetRequiredService<IVsEventHandlingService>();
             fileStorageEventHandling = ServiceProvider.GetRequiredService<IFileStorageEventHandlingService>();
+            cpsProjectConfigService = ServiceProvider.GetRequiredService<ICpsProjectConfigService>();
         }
 
         protected override void Dispose(bool disposing)
@@ -170,6 +172,7 @@ namespace SmartCmdArgs
             services.AddLazySingleton<SettingsViewModel>();
             services.AddLazySingleton<ToolWindowViewModel>();
             services.AddLazySingleton<TreeViewModel>();
+            services.AddLazySingleton<ICpsProjectConfigService, CpsProjectConfigService>();
             services.AddLazySingleton<IProjectConfigService, ProjectConfigService>();
             services.AddSingleton<IVisualStudioHelperService, VisualStudioHelperService>();
             services.AddSingleton<IFileStorageService, FileStorageService>();
@@ -262,7 +265,7 @@ namespace SmartCmdArgs
             List<string> launchProfiles = null;
             if (project?.IsCpsProject() == true)
             {
-                launchProfiles = CpsProjectSupport.GetLaunchProfileNames(project.GetProject())?.ToList();
+                launchProfiles = cpsProjectConfigService.GetLaunchProfileNames(project.GetProject())?.ToList();
             }
 
             return launchProfiles ?? new List<string>();

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Services/ItemAggregationService.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Services/ItemAggregationService.cs
@@ -1,4 +1,4 @@
-﻿using SmartCmdArgs.Helper;
+using SmartCmdArgs.Helper;
 using SmartCmdArgs.ViewModel;
 using SmartCmdArgs.Wrapper;
 using System;
@@ -23,15 +23,19 @@ namespace SmartCmdArgs.Services
         private readonly IItemEvaluationService itemEvaluation;
         private readonly IVisualStudioHelperService vsHelper;
         private readonly TreeViewModel treeViewModel;
+        private readonly ICpsProjectConfigService cpsProjectConfigService;
+
 
         public ItemAggregationService(
             IItemEvaluationService itemEvaluation,
             IVisualStudioHelperService vsHelper,
-            TreeViewModel treeViewModel)
+            TreeViewModel treeViewModel,
+            ICpsProjectConfigService cpsProjectConfigService)
         {
             this.itemEvaluation = itemEvaluation;
             this.vsHelper = vsHelper;
             this.treeViewModel = treeViewModel;
+            this.cpsProjectConfigService = cpsProjectConfigService;
         }
 
         private TResult AggregateComamndLineItemsForProject<TResult>(IVsHierarchyWrapper project, Func<IEnumerable<CmdBase>, Func<CmdContainer, TResult>, CmdContainer, TResult> joinItems)
@@ -50,7 +54,7 @@ namespace SmartCmdArgs.Services
 
             string activeLaunchProfile = null;
             if (project.IsCpsProject())
-                activeLaunchProfile = CpsProjectSupport.GetActiveLaunchProfileName(projectObj);
+                activeLaunchProfile = cpsProjectConfigService.GetActiveLaunchProfileName(projectObj);
 
             TResult JoinContainer(CmdContainer con)
             {

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Services/OptionsSettingsEventHandlingService.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Services/OptionsSettingsEventHandlingService.cs
@@ -1,5 +1,6 @@
-﻿using SmartCmdArgs.ViewModel;
+using SmartCmdArgs.ViewModel;
 using System;
+using System.Linq;
 
 namespace SmartCmdArgs.Services
 {
@@ -18,6 +19,8 @@ namespace SmartCmdArgs.Services
         private readonly IViewModelUpdateService viewModelUpdateService;
         private readonly ToolWindowViewModel toolWindowViewModel;
         private readonly IToolWindowHistory toolWindowHistory;
+        private readonly IProjectConfigService projectConfigService;
+        private readonly ICpsProjectConfigService cpsProjectConfigService;
 
         public OptionsSettingsEventHandlingService(
             IOptionsSettingsService optionsSettings,
@@ -26,7 +29,9 @@ namespace SmartCmdArgs.Services
             IVisualStudioHelperService vsHelper,
             IViewModelUpdateService viewModelUpdateService,
             ToolWindowViewModel toolWindowViewModel,
-            IToolWindowHistory toolWindowHistory)
+            IToolWindowHistory toolWindowHistory,
+            IProjectConfigService projectConfigService,
+            ICpsProjectConfigService cpsProjectConfigService)
         {
             this.optionsSettings = optionsSettings;
             this.settingsService = settingsService;
@@ -35,6 +40,8 @@ namespace SmartCmdArgs.Services
             this.viewModelUpdateService = viewModelUpdateService;
             this.toolWindowViewModel = toolWindowViewModel;
             this.toolWindowHistory = toolWindowHistory;
+            this.projectConfigService = projectConfigService;
+            this.cpsProjectConfigService = cpsProjectConfigService;
         }
 
         public void Dispose()
@@ -64,6 +71,7 @@ namespace SmartCmdArgs.Services
                 case nameof(IOptionsSettingsService.JsonRootPath): JsonRootPathChanged(); break;
                 case nameof(IOptionsSettingsService.VcsSupportEnabled): VcsSupportChanged(); break;
                 case nameof(IOptionsSettingsService.UseSolutionDir): UseSolutionDirChanged(); break;
+                case nameof(IOptionsSettingsService.UseCpsVirtualProfile): UseCpsVirtualProfileChanged(); break;
                 case nameof(IOptionsSettingsService.ManageCommandLineArgs): viewModelUpdateService.UpdateIsActiveForParamsDebounced(); break;
                 case nameof(IOptionsSettingsService.ManageEnvironmentVars): viewModelUpdateService.UpdateIsActiveForParamsDebounced(); break;
                 case nameof(IOptionsSettingsService.ManageWorkingDirectories): viewModelUpdateService.UpdateIsActiveForParamsDebounced(); break;
@@ -117,6 +125,14 @@ namespace SmartCmdArgs.Services
         {
             fileStorage.DeleteAllUnusedArgFiles();
             fileStorage.SaveAllProjects();
+        }
+        private void UseCpsVirtualProfileChanged()
+        {
+            foreach (var project in vsHelper.GetSupportedProjects().Where(x => x.IsCpsProject()))
+            {
+                projectConfigService.UpdateProjectConfig(project);
+                cpsProjectConfigService.SetActiveLaunchProfileToVirtualProfile(project.GetProject());
+            }
         }
     }
 }

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Services/OptionsSettingsService.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Services/OptionsSettingsService.cs
@@ -1,4 +1,4 @@
-﻿using SmartCmdArgs.Helper;
+using SmartCmdArgs.Helper;
 using SmartCmdArgs.ViewModel;
 using System;
 using System.ComponentModel;
@@ -23,6 +23,7 @@ namespace SmartCmdArgs.Services
         bool UseSolutionDir { get; }
 
         // Options
+        bool UseCpsVirtualProfile { get; }
         bool UseMonospaceFont { get; }
         bool DisplayTagForCla { get; }
         bool DeleteEmptyFilesAutomatically { get; }
@@ -67,6 +68,11 @@ namespace SmartCmdArgs.Services
         public bool UseSolutionDir => _vsHelperService?.GetSolutionFilename() != null && (settingsViewModel.UseSolutionDir ?? OptionsPage.UseSolutionDir);
 
         // Options
+#if VS17
+        public bool UseCpsVirtualProfile => OptionsPage.UseCpsVirtualProfile;
+#else
+        public bool UseCpsVirtualProfile => false;
+#endif
         public bool UseMonospaceFont => OptionsPage.UseMonospaceFont;
         public bool DisplayTagForCla => OptionsPage.DisplayTagForCla;
         public bool DeleteEmptyFilesAutomatically => OptionsPage.DeleteEmptyFilesAutomatically;

--- a/SmartCmdArgs/SmartCmdArgs.Shared/SmartCmdArgs.Shared.projitems
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/SmartCmdArgs.Shared.projitems
@@ -14,7 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Commands.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomMonikers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helper\BindingListEx.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Helper\CpsProjectSupport.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helper\CpsProjectConfigService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)helper\Debouncer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helper\DelayExecution.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helper\EnumDescConverter.cs" />

--- a/SmartCmdArgs/SmartCmdArgs17/SmartCmdArgs17.csproj
+++ b/SmartCmdArgs/SmartCmdArgs17/SmartCmdArgs17.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
@@ -99,11 +99,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>7.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
-      <Version>15.8.243</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed">
-      <Version>2.0.6142705</Version>
+    <PackageReference Include="CI.Microsoft.VisualStudio.ProjectSystem.Managed">
+      <Version>17.11.1.102</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4065">

--- a/SmartCmdArgs/Testing/SmartCmdArgs.Tests/Services/ItemAggregationServiceTests.cs
+++ b/SmartCmdArgs/Testing/SmartCmdArgs.Tests/Services/ItemAggregationServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+using Moq;
 using System;
 using System.Collections.Generic;
 using SmartCmdArgs.ViewModel;
@@ -19,6 +19,7 @@ namespace SmartCmdArgs.Tests.Services
         private readonly Mock<IItemEvaluationService> itemEvaluationServiceMock;
         private readonly Mock<IVisualStudioHelperService> vsHelperServiceMock;
         private readonly Mock<IToolWindowHistory> toolWindowHistoryMock;
+        private readonly Mock<ICpsProjectConfigService> cpsProjectConfigService;
         private readonly TreeViewModel treeViewModel;
         private readonly ItemAggregationService itemAggregationService;
 
@@ -29,6 +30,7 @@ namespace SmartCmdArgs.Tests.Services
             itemEvaluationServiceMock = new Mock<IItemEvaluationService>();
             vsHelperServiceMock = new Mock<IVisualStudioHelperService>();
             toolWindowHistoryMock = new Mock<IToolWindowHistory>();
+            cpsProjectConfigService = new Mock<ICpsProjectConfigService>();
             treeViewModel = new TreeViewModel(toolWindowHistoryMock.LazyObject());
 
             itemEvaluationServiceMock.Setup(x => x.EvaluateMacros(It.IsAny<string>(), It.IsAny<IVsHierarchyWrapper>())).Returns<string, IVsHierarchyWrapper>((arg, _) => arg);
@@ -36,7 +38,8 @@ namespace SmartCmdArgs.Tests.Services
             itemAggregationService = new ItemAggregationService(
                 itemEvaluationServiceMock.Object,
                 vsHelperServiceMock.Object,
-                treeViewModel
+                treeViewModel,
+                cpsProjectConfigService.Object
             );
         }
 


### PR DESCRIPTION
#151 and #147

Not ready for committing yet.  There is a problem with older vs versions (even 17.10 for example) where it throws an error.   I am thinking we need an older version of the `Microsoft.VisualStudio.ProjectSystem.Managed` package.  I used a 17.11 version so maybe that somehow only works in versions of VS newer than that.

Note this eliminates the dependency on the beta feed.  It uses what I mentioned in https://github.com/dotnet/project-system/issues/7010 of putting the nuget package together myself.    nuget also ensures it will never go stale un-avail again.   

I will try the oldest version of the package that has the in memory support see if that resolves this issue.   

Note this code is not taken directly from the old branch I manually re-merged the differences in to make sure it had all the changes from master.  The changes with `InitConfigHandlerForSupportedProjects` I am not sure if should be part of this PR but they were added originally and not yet in master so I did leave them there.


There is some chance we might be able to accomplish this with a reflection only solution.  This is a bit tricky as we need to implement an interface rather than just call a function or two, but is not impossible (I believe).  

I plan to post in 7010 above as well after some more testing.