### PR TITLE
Add support for specifying custom debugger rules in config file

### DIFF
--- a/MarketplaceOverview.md
+++ b/MarketplaceOverview.md
@@ -79,6 +79,41 @@ Options can be found at `Tools → Options → Smart Commandline Arguments`.
 ### Settings Defaults
 This contols the default behaviour for [Settings](#user-content-settings)
 
+### Custom Debugger Rules
+
+The extension ships with built-in support for common C/C++ debugger flavors (Windows Local/Remote, Linux, WSL, Android, Oasis NX, etc.). If your project uses a debugger flavor that is not listed above, you can register it via a JSON config file without modifying the extension.
+
+Create a file at:
+
+```
+%LOCALAPPDATA%\SmartCmdArgs\custom_debugger_rules.json
+```
+
+The file contains a JSON array of rule objects. Each rule maps a debugger flavor (the `DebuggerFlavor` value in your `.vcxproj.user`) to the project properties the extension should read from and write to:
+
+```json
+[
+  {
+    "RuleName": "MyCustomDebugger",
+    "ArgsPropName": "RemoteDebuggerCommandArguments",
+    "EnvPropName": "RemoteDebuggerEnvironment",
+    "WorkDirPropName": "RemoteDebuggerWorkingDirectory",
+    "LaunchAppPropName": "RemoteDebuggerCommand"
+  }
+]
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `RuleName` | Yes | The debugger flavor name, matching the `DebuggerFlavor` property in the `.vcxproj.user` file. |
+| `ArgsPropName` | Yes | The property name for command line arguments. |
+| `EnvPropName` | No | The property name for environment variables. |
+| `WorkDirPropName` | No | The property name for the working directory. |
+| `LaunchAppPropName` | No | The property name for the launch application/command. |
+
+Rules with a `RuleName` that duplicates a built-in rule are ignored. Errors loading the file are logged to the Visual Studio Activity Log.
+
+To find the correct `RuleName` for your debugger, set the debugger flavor and some arguments in Visual Studio, save, and inspect the `<DebuggerFlavor>` value under `DebuggerGeneralProperties` in your `.vcxproj.user` file.
 
 ### Hotkeys
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,42 @@ Options can be found at `Tools → Options → Smart Commandline Arguments`.
 ### Settings Defaults
 This contols the default behaviour for [Settings](#settings)
 
+### Custom Debugger Rules
+
+The extension ships with built-in support for common C/C++ debugger flavors (Windows Local/Remote, Linux, WSL, Android, Oasis NX, etc.). If your project uses a debugger flavor that is not listed above, you can register it via a JSON config file without modifying the extension.
+
+Create a file at:
+
+```
+%LOCALAPPDATA%\SmartCmdArgs\custom_debugger_rules.json
+```
+
+The file contains a JSON array of rule objects. Each rule maps a debugger flavor (the `DebuggerFlavor` value in your `.vcxproj.user`) to the project properties the extension should read from and write to:
+
+```json
+[
+  {
+    "RuleName": "MyCustomDebugger",
+    "ArgsPropName": "RemoteDebuggerCommandArguments",
+    "EnvPropName": "RemoteDebuggerEnvironment",
+    "WorkDirPropName": "RemoteDebuggerWorkingDirectory",
+    "LaunchAppPropName": "RemoteDebuggerCommand"
+  }
+]
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `RuleName` | Yes | The debugger flavor name, matching the `DebuggerFlavor` property in the `.vcxproj.user` file. |
+| `ArgsPropName` | Yes | The property name for command line arguments. |
+| `EnvPropName` | No | The property name for environment variables. |
+| `WorkDirPropName` | No | The property name for the working directory. |
+| `LaunchAppPropName` | No | The property name for the launch application/command. |
+
+Rules with a `RuleName` that duplicates a built-in rule are ignored. Errors loading the file are logged to the Visual Studio Activity Log.
+
+To find the correct `RuleName` for your debugger, set the debugger flavor and some arguments in Visual Studio, save, and inspect the `<DebuggerFlavor>` value under `DebuggerGeneralProperties` in your `.vcxproj.user` file.
+
 ## Hotkeys
 - <kbd>CTRL</kbd>+<kbd>↑</kbd> / <kbd>CTRL</kbd>+<kbd>↓</kbd>: Move selected items.
 - <kbd>Space</kbd>: Disable/Enable selected items.

--- a/SmartCmdArgs/SmartCmdArgs.Shared/Services/ProjectConfigService.cs
+++ b/SmartCmdArgs/SmartCmdArgs.Shared/Services/ProjectConfigService.cs
@@ -1,9 +1,11 @@
 using Microsoft.VisualStudio.Shell;
-using SmartCmdArgs.Helper;
+using Newtonsoft.Json;
 using SmartCmdArgs.DataSerialization;
+using SmartCmdArgs.Helper;
 using SmartCmdArgs.Wrapper;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace SmartCmdArgs.Services
@@ -279,7 +281,20 @@ namespace SmartCmdArgs.Services
 
         #region VCProjEngine (C/C++)
 
-        private static readonly List<(string RuleName, string ArgsPropName, string EnvPropName, string WorkDirPropName, string LaunchAppPropName)> VCPropInfo = new List<(string RuleName, string PropName, string EnvPropName, string WorkDirPropName, string LaunchAppPropName)>
+        private static readonly List<(string RuleName, string ArgsPropName, string EnvPropName, string WorkDirPropName, string LaunchAppPropName)> VCPropInfo = LoadVCPropInfo();
+
+        private class CustomDebuggerRule
+        {
+            public string RuleName { get; set; }
+            public string ArgsPropName { get; set; }
+            public string EnvPropName { get; set; }
+            public string WorkDirPropName { get; set; }
+            public string LaunchAppPropName { get; set; }
+        }
+
+        private static List<(string RuleName, string ArgsPropName, string EnvPropName, string WorkDirPropName, string LaunchAppPropName)> LoadVCPropInfo()
+        {
+            var list = new List<(string, string, string, string, string)>
             {
                 ("WindowsLocalDebugger", "LocalDebuggerCommandArguments", "LocalDebuggerEnvironment", "LocalDebuggerWorkingDirectory", "LocalDebuggerCommand"),
                 ("WindowsRemoteDebugger", "RemoteDebuggerCommandArguments", "RemoteDebuggerEnvironment", "RemoteDebuggerWorkingDirectory", "RemoteDebuggerCommand"),
@@ -290,6 +305,47 @@ namespace SmartCmdArgs.Services
                 ("LinuxDebugger", "RemoteDebuggerCommandArguments", null, "RemoteDebuggerWorkingDirectory", null),
                 ("AppHostLocalDebugger", "CommandLineArgs", null, null, null),
             };
+
+            try
+            {
+                string configDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SmartCmdArgs");
+                string configPath = Path.Combine(configDir, "custom_debugger_rules.json");
+
+                if (File.Exists(configPath))
+                {
+                    string json = File.ReadAllText(configPath);
+                    var customRules = JsonConvert.DeserializeObject<List<CustomDebuggerRule>>(json);
+                    if (customRules != null)
+                    {
+                        var existingNames = new HashSet<string>(list.Select(r => r.Item1), StringComparer.OrdinalIgnoreCase);
+                        foreach (var rule in customRules)
+                        {
+                            if (string.IsNullOrEmpty(rule.RuleName) || string.IsNullOrEmpty(rule.ArgsPropName))
+                            {
+                                Logger.Warn($"Skipping custom debugger rule with missing RuleName or ArgsPropName.");
+                                continue;
+                            }
+                            if (existingNames.Contains(rule.RuleName))
+                            {
+                                Logger.Warn($"Custom debugger rule '{rule.RuleName}' duplicates a built-in rule; ignoring.");
+                            }
+                            else
+                            {
+                                list.Add((rule.RuleName, rule.ArgsPropName, rule.EnvPropName, rule.WorkDirPropName, rule.LaunchAppPropName));
+                                existingNames.Add(rule.RuleName);
+                                Logger.Info($"Loaded custom debugger rule '{rule.RuleName}' from '{configPath}'.");
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to load custom debugger rules from config file", ex);
+            }
+
+            return list;
+        }
 
         private static void SetVCProjEngineConfig(EnvDTE.Project project, string arguments, IDictionary<string, string> envVars, string workDir, string launchApp)
         {


### PR DESCRIPTION
This is a supplement or alternative to #196. Would avoid the need to update the extension if extra debugger rules are needed by someone in the future.

Copied from the readme additions:

### Custom Debugger Rules

The extension ships with built-in support for common C/C++ debugger flavors (Windows Local/Remote, Linux, WSL, Android, Oasis NX, etc.). If your project uses a debugger flavor that is not listed above, you can register it via a JSON config file without modifying the extension.

Create a file at:

```
%LOCALAPPDATA%\SmartCmdArgs\custom_debugger_rules.json
```

The file contains a JSON array of rule objects. Each rule maps a debugger flavor (the `DebuggerFlavor` value in your `.vcxproj.user`) to the project properties the extension should read from and write to:

```json
[
  {
    "RuleName": "MyCustomDebugger",
    "ArgsPropName": "RemoteDebuggerCommandArguments",
    "EnvPropName": "RemoteDebuggerEnvironment",
    "WorkDirPropName": "RemoteDebuggerWorkingDirectory",
    "LaunchAppPropName": "RemoteDebuggerCommand"
  }
]
```

| Field | Required | Description |
|---|---|---|
| `RuleName` | Yes | The debugger flavor name, matching the `DebuggerFlavor` property in the `.vcxproj.user` file. |
| `ArgsPropName` | Yes | The property name for command line arguments. |
| `EnvPropName` | No | The property name for environment variables. |
| `WorkDirPropName` | No | The property name for the working directory. |
| `LaunchAppPropName` | No | The property name for the launch application/command. |

Rules with a `RuleName` that duplicates a built-in rule are ignored. Errors loading the file are logged to the Visual Studio Activity Log.

To find the correct `RuleName` for your debugger, set the debugger flavor and some arguments in Visual Studio, save, and inspect the `<DebuggerFlavor>` value under `DebuggerGeneralProperties` in your `.vcxproj.user` file.